### PR TITLE
fix process010 test run on Solaris where false exits with status 255

### DIFF
--- a/tests/process010.stdout-i386-unknown-solaris2
+++ b/tests/process010.stdout-i386-unknown-solaris2
@@ -1,0 +1,4 @@
+ExitSuccess
+ExitFailure 255
+Exc: /non/existent: rawSystem: runInteractiveProcess: exec: does not exist (No such file or directory)
+Done


### PR DESCRIPTION
Solaris provides false command in /usr/bin/false which is executed by this testcase and which exits with status code 255. On the other hand Solaris' shell's false builtin exits with status code 1 so it's quite a mess actually, but anyway false should exit with something different from 0 and both fulfil this so I provide this to make the test pass on Solaris.
