### PR TITLE
Build Haddock documentation for System.Process.Internals

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP, RecordWildCards, BangPatterns #-}
-{-# OPTIONS_HADDOCK hide #-}
 #ifdef __GLASGOW_HASKELL__
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE InterruptibleFFI #-}
@@ -15,7 +14,8 @@
 -- Stability   :  experimental
 -- Portability :  portable
 --
--- Operations for creating and interacting with sub-processes.
+-- /Note:/ This module exports internal implementation details that may change
+-- anytime.  If you want a more stable API, use "System.Process" instead.
 --
 -----------------------------------------------------------------------------
 


### PR DESCRIPTION
From my perspective the module name already clearly states that this is
internal stuff + currently we have a 404 on Hackage for this one + I
actually want to read the Haddocks.
