### PR TITLE
Tighten Safe Haskell bounds, fixes new warning in GHC 7.10.

### DIFF
--- a/System/Cmd.hs
+++ b/System/Cmd.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
-#ifdef __GLASGOW_HASKELL__
+#if __GLASGOW_HASKELL__ >= 709
+{-# LANGUAGE Safe #-}
+#elif __GLASGOW_HASKELL__ >= 703
 {-# LANGUAGE Trustworthy #-}
 #endif
 


### PR DESCRIPTION
Some of the Safe Haskell bounds can be improved. This also fixes warnings that will appear in 7.10 where we have a new warning flag (`--fwarn-trustworthy-safe`) that warns when a trustworthy module could be instead marked safe.
