### PR TITLE
Add StdStream(NoStream) to have standard handles closed.

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -223,6 +223,7 @@ data StdStream
                              -- @Handle@ will use the default encoding
                              -- and newline translation mode (just
                              -- like @Handle@s created by @openFile@).
+  | NoStream                 -- ^ No stream handle will be passed
 
 -- | This function is almost identical to
 -- 'System.Process.createProcess'. The only differences are:
@@ -491,6 +492,7 @@ fd_stderr = 2
 mbFd :: String -> FD -> StdStream -> IO FD
 mbFd _   _std CreatePipe      = return (-1)
 mbFd _fun std Inherit         = return std
+mbFd _fn _std NoStream        = return (-2)
 mbFd fun _std (UseHandle hdl) =
   withHandle fun hdl $ \Handle__{haDevice=dev,..} ->
     case cast dev of

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -162,6 +162,8 @@ runInteractiveProcess (char *const args[],
                 close(fdStdInput[0]);
             }
             close(fdStdInput[1]);
+        } else if (fdStdIn == -2) {
+            close(STDIN_FILENO);
         } else {
             dup2(fdStdIn,  STDIN_FILENO);
         }
@@ -172,6 +174,8 @@ runInteractiveProcess (char *const args[],
                 close(fdStdOutput[1]);
             }
             close(fdStdOutput[0]);
+        } else if (fdStdOut == -2) {
+            close(STDOUT_FILENO);
         } else {
             dup2(fdStdOut,  STDOUT_FILENO);
         }
@@ -182,6 +186,8 @@ runInteractiveProcess (char *const args[],
                 close(fdStdError[1]);
             }
             close(fdStdError[0]);
+        } else if (fdStdErr == -2) {
+            close(STDERR_FILENO);
         } else {
             dup2(fdStdErr,  STDERR_FILENO);
         }
@@ -474,6 +480,8 @@ runInteractiveProcess (wchar_t *cmd, wchar_t *workingDirectory,
         if (!mkAnonPipe(&hStdInputRead,  TRUE, &hStdInputWrite,  FALSE))
             goto cleanup_err;
         sInfo.hStdInput = hStdInputRead;
+    } else if (fdStdIn == -2) {
+        sInfo.hStdInput = NULL;
     } else if (fdStdIn == 0) {
         // Don't duplicate stdin, as console handles cannot be
         // duplicated and inherited. urg.
@@ -494,6 +502,8 @@ runInteractiveProcess (wchar_t *cmd, wchar_t *workingDirectory,
         if (!mkAnonPipe(&hStdOutputRead,  FALSE, &hStdOutputWrite,  TRUE))
             goto cleanup_err;
         sInfo.hStdOutput = hStdOutputWrite;
+    } else if (fdStdOut == -2) {
+        sInfo.hStdOutput = NULL;
     } else if (fdStdOut == 1) {
         // Don't duplicate stdout, as console handles cannot be
         // duplicated and inherited. urg.
@@ -514,6 +524,8 @@ runInteractiveProcess (wchar_t *cmd, wchar_t *workingDirectory,
         if (!mkAnonPipe(&hStdErrorRead,  TRUE, &hStdErrorWrite,  TRUE))
             goto cleanup_err;
         sInfo.hStdError = hStdErrorWrite;
+    } else if (fdStdErr == -2) {
+        sInfo.hStdError = NULL;
     } else if (fdStdErr == 2) {
         // Don't duplicate stderr, as console handles cannot be
         // duplicated and inherited. urg.


### PR DESCRIPTION
The motivation is that lots of processes behave differently when (especially) stdin is
closed vs when it's a pipe.