### PR TITLE
Wait on child PID after failed exec

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -288,6 +288,11 @@ runInteractiveProcess (char *const args[],
             // get the errno of whatever else went wrong instead.
             errno = err;
         }
+
+        // We forked the child, but the child had a problem and stopped so it's
+        // our responsibility to reap here as nobody else can.
+        waitpid(pid, NULL, 0);
+
         pid = -1;
     }
     else if (r != 0) {


### PR DESCRIPTION
On Linux, the following program generates 10 zombie processes, one for each time that `callProcess` tries to call a nonexistent process.

    import Control.Concurrent
    import Control.Exception
    import Control.Monad
    import System.IO
    import System.Process

    ignoreIOException :: IOException -> IO ()
    ignoreIOException _ = return ()

    main = do
      _ <- forkIO $ replicateM_ 10 $ callProcess "does-not-exist" [] `catch` ignoreIOException
      _ <- getLine
      return ()

The reason seems to be that the child PID leaks because the parent does not call waitpid() if the child has failed. This simple change seems to fix it.
