### PR TITLE
Add readCreateProcess function

### DIFF
--- a/System/Process.hsc
+++ b/System/Process.hsc
@@ -422,6 +422,8 @@ readProcess cmd args = readCreateProcess $ proc cmd args
 -- >  > readCreateProcess (shell "pwd" { cwd = "/etc/" }) ""
 -- >  "/etc\n"
 --
+-- Note that @Handle@s provided for @std_in@ or @std_out@ via the CreateProcess
+-- record will be ignored.
 -- /Since: 1.2.3.0/
 
 readCreateProcess
@@ -432,7 +434,6 @@ readCreateProcess cp input = do
     let cp_opts = cp {
                     std_in  = CreatePipe,
                     std_out = CreatePipe,
-                    std_err = Inherit
                   }
     (ex, output) <- withCreateProcess_ "readCreateProcess" cp_opts $
       \(Just inh) (Just outh) _ ph -> do

--- a/System/Process.hsc
+++ b/System/Process.hsc
@@ -433,7 +433,7 @@ readCreateProcess
 readCreateProcess cp input = do
     let cp_opts = cp {
                     std_in  = CreatePipe,
-                    std_out = CreatePipe,
+                    std_out = CreatePipe
                   }
     (ex, output) <- withCreateProcess_ "readCreateProcess" cp_opts $
       \(Just inh) (Just outh) _ ph -> do

--- a/System/Process.hsc
+++ b/System/Process.hsc
@@ -421,6 +421,8 @@ readProcess cmd args = readCreateProcess $ proc cmd args
 --
 -- >  > readCreateProcess (shell "pwd" { cwd = "/etc/" }) ""
 -- >  "/etc\n"
+--
+-- /Since: 1.2.3.0/
 
 readCreateProcess
     :: CreateProcess

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
   * [Meaningful error message when exe not found on close\_fds is
   True](https://ghc.haskell.org/trac/ghc/ticket/3649#comment:10)
 
+  * New function `readCreateProcess`
+
 ## 1.2.2.0  *Jan 2015*
 
   * Fix delegated CTRL-C handling in `createProcess` in case of failed


### PR DESCRIPTION
This function is more flexible then readProcess, for example it allows
you to change the working directory before running the command.


This loses a bit in terms of error reporting. I'm also not sure if extending the API is the right thing to do. Another way to achieve what I want would be to expose withCreateProcess_, withForkWait, ignoreSigPipe, processFailedException functions in System.Process.Internals. 