### PR TITLE
Update 2 GHC tests

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -22,7 +22,7 @@ test('T3231',
      compile_and_run,
      [''])
 test('T4198',
-     [pre_cmd('\'' + config.compiler + '\'' + ' exitminus1.c -no-hs-main -o exitminus1'),
+     [pre_cmd('{compiler} exitminus1.c -no-hs-main -o exitminus1'),
       extra_clean(['exitminus1.o', 'exitminus1', 'exitminus1.exe'])],
      compile_and_run,
      [''])

--- a/tests/process006.stdout
+++ b/tests/process006.stdout
@@ -1,4 +1,4 @@
 "yan\ntan\tether\n"
 (ExitSuccess,"yan\ntan\tether\n","")
 (ExitFailure 3,"stdout\n","stderr\n")
-Left readProcess: sh "-c" "echo stdout; echo stderr 1>&2; exit 3" (exit 3): failed
+Left readCreateProcess: sh "-c" "echo stdout; echo stderr 1>&2; exit 3" (exit 3): failed


### PR DESCRIPTION
The first commit is needed for `process master` to pass GHC validation, after the recent addition of `readCreateProcess`.

The second commit makes the `process` testsuite compatible with some changes I have planned for the GHC test framework.