### PR TITLE
Windows: delete redundant import in System/Process.hsc

### DIFF
--- a/System/Process.hsc
+++ b/System/Process.hsc
@@ -91,7 +91,6 @@ import System.IO.Error (mkIOError, ioeSetErrorString)
 # include <io.h>        /* for _close and _pipe */
 # include <fcntl.h>     /* for _O_BINARY */
 import Control.Exception (onException)
-import Foreign.C.Types (CInt(..), CUInt(..))
 #else
 import System.Posix.Process (getProcessGroupIDOf)
 import qualified System.Posix.IO as Posix


### PR DESCRIPTION
Building GHC on Windows shows the following warning:

  libraries/process/System/Process.hsc:94:1: warning:
      The import of ‘Foreign.C.Types’ is redundant
        except perhaps to import instances from ‘Foreign.C.Types’
      To import instances alone, use: import Foreign.C.Types()