### PR TITLE
Fix #46

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -237,7 +237,7 @@ withCreateProcess_ fun c action =
 cleanupProcess :: (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
                -> IO ()
 cleanupProcess (mb_stdin, mb_stdout, mb_stderr,
-                ph@(ProcessHandle _ delegating_ctlc)) = do
+                ph@(ProcessHandle _ delegating_ctlc _)) = do
     terminateProcess ph
     -- Note, it's important that other threads that might be reading/writing
     -- these handles also get killed off, since otherwise they might be holding
@@ -258,7 +258,7 @@ cleanupProcess (mb_stdin, mb_stdout, mb_stderr,
     _ <- forkIO (waitForProcess (resetCtlcDelegation ph) >> return ())
     return ()
   where
-    resetCtlcDelegation (ProcessHandle m _) = ProcessHandle m False
+    resetCtlcDelegation (ProcessHandle m _ l) = ProcessHandle m False l
 
 -- ----------------------------------------------------------------------------
 -- spawnProcess/spawnCommand
@@ -584,14 +584,11 @@ detail.
 waitForProcess
   :: ProcessHandle
   -> IO ExitCode
-waitForProcess ph@(ProcessHandle _ delegating_ctlc) = do
+waitForProcess ph@(ProcessHandle _ delegating_ctlc _) = lockWaitpid $ do
   p_ <- modifyProcessHandle ph $ \p_ -> return (p_,p_)
   case p_ of
     ClosedHandle e -> return e
     OpenHandle h  -> do
-        -- don't hold the MVar while we call c_waitForProcess...
-        -- (XXX but there's a small race window here during which another
-        -- thread could close the handle or call waitForProcess)
         e <- alloca $ \pret -> do
           throwErrnoIfMinus1Retry_ "waitForProcess" (c_waitForProcess h pret)
           modifyProcessHandle ph $ \p_' ->
@@ -616,6 +613,7 @@ waitForProcess ph@(ProcessHandle _ delegating_ctlc) = do
 #else
         return $ ExitFailure (-1)
 #endif
+  where lockWaitpid m = withMVar (waitpidLock ph) $ \() -> m
 
 -- ----------------------------------------------------------------------------
 -- getProcessExitCode
@@ -630,7 +628,7 @@ when the process died as the result of a signal.
 -}
 
 getProcessExitCode :: ProcessHandle -> IO (Maybe ExitCode)
-getProcessExitCode ph@(ProcessHandle _ delegating_ctlc) = do
+getProcessExitCode ph@(ProcessHandle _ delegating_ctlc _) = do
   (m_e, was_open) <- modifyProcessHandle ph $ \p_ ->
     case p_ of
       ClosedHandle e -> return (p_, (Just e, False))

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -679,7 +679,7 @@ getProcessExitCode ph@(ProcessHandle _ delegating_ctlc _) = tryLockWaitpid $ do
                 Just () -> putMVar (waitpidLock ph) ()
               between m = case m of
                 Nothing -> return Nothing
-                Just () -> do     action
+                Just () -> action
 
 -- ----------------------------------------------------------------------------
 -- terminateProcess

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -177,7 +177,11 @@ data StdStream
 data ProcessHandle__ = OpenHandle PHANDLE
                      | OpenExtHandle PHANDLE PHANDLE PHANDLE
                      | ClosedHandle ExitCode
-data ProcessHandle = ProcessHandle !(MVar ProcessHandle__) !Bool
+data ProcessHandle
+  = ProcessHandle { phandle          :: !(MVar ProcessHandle__)
+                  , mb_delegate_ctlc :: !Bool
+                  , waitpidLock      :: !(MVar ())
+                  }
 
 withFilePathException :: FilePath -> IO a -> IO a
 withFilePathException fpath act = handle mapEx act
@@ -188,13 +192,13 @@ modifyProcessHandle
         :: ProcessHandle
         -> (ProcessHandle__ -> IO (ProcessHandle__, a))
         -> IO a
-modifyProcessHandle (ProcessHandle m _) io = modifyMVar m io
+modifyProcessHandle (ProcessHandle m _ _) io = modifyMVar m io
 
 withProcessHandle
         :: ProcessHandle
         -> (ProcessHandle__ -> IO a)
         -> IO a
-withProcessHandle (ProcessHandle m _) io = withMVar m io
+withProcessHandle (ProcessHandle m _ _) io = withMVar m io
 
 fd_stdin, fd_stdout, fd_stderr :: FD
 fd_stdin  = 0

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -48,7 +48,8 @@ import System.Process.Common
 mkProcessHandle :: PHANDLE -> Bool -> IO ProcessHandle
 mkProcessHandle p mb_delegate_ctlc = do
   m <- newMVar (OpenHandle p)
-  return (ProcessHandle m mb_delegate_ctlc)
+  l <- newMVar ()
+  return (ProcessHandle m mb_delegate_ctlc l)
 
 closePHANDLE :: PHANDLE -> IO ()
 closePHANDLE _ = return ()

--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -66,7 +66,8 @@ mkProcessHandle h job io = do
            then newMVar (OpenHandle h)
            else newMVar (OpenExtHandle h job io)
    _ <- mkWeakMVar m (processHandleFinaliser m)
-   return (ProcessHandle m False)
+   l <- newMVar ()
+   return (ProcessHandle m False l)
 
 processHandleFinaliser :: MVar ProcessHandle__ -> IO ()
 processHandleFinaliser m =

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -425,11 +425,6 @@ int waitForProcess (ProcHandle handle, int *pret)
 
     if (waitpid(handle, &wstat, 0) < 0)
     {
-        if (errno == ECHILD)
-        {
-            *pret = 0;
-            return 1;
-        }
         return -1;
     }
 

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -425,6 +425,11 @@ int waitForProcess (ProcHandle handle, int *pret)
 
     if (waitpid(handle, &wstat, 0) < 0)
     {
+        if (errno == ECHILD)
+        {
+            *pret = 0;
+            return 1;
+        }
         return -1;
     }
 

--- a/process.cabal
+++ b/process.cabal
@@ -82,3 +82,5 @@ test-suite test
                , bytestring
                , directory
                , process
+  ghc-options: -threaded
+               -with-rtsopts "-N"

--- a/test/main.hs
+++ b/test/main.hs
@@ -1,10 +1,12 @@
 import Control.Exception
-import Control.Monad (unless)
+import Control.Monad (unless, void)
 import System.Exit
 import System.IO.Error
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
 import System.Process
+import Control.Concurrent
 import Data.List (isInfixOf)
+import Data.Maybe (isNothing)
 import System.IO (hClose, openBinaryTempFile)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
@@ -65,6 +67,17 @@ main = do
             $ error $ "Unexpected exit code " ++ show ec
         unless (bs == res')
             $ error $ "Unexpected result: " ++ show res'
+
+    do -- multithreaded waitForProcess
+      (_, _, _, p) <- createProcess (proc "sleep" ["0.1"])
+      me1 <- newEmptyMVar
+      forkIO . void $ waitForProcess p >>= putMVar me1
+      -- check for race / deadlock between waitForProcess and getProcessExitCode
+      e3 <- getProcessExitCode p
+      e2 <- waitForProcess p
+      e1 <- readMVar me1
+      unless (isNothing e3 && e1 == ExitSuccess && e2 == ExitSuccess)
+            $ error "sleep exited with non-zero exit code!"
 
     putStrLn "Tests passed successfully"
 

--- a/test/main.hs
+++ b/test/main.hs
@@ -71,12 +71,14 @@ main = do
     do -- multithreaded waitForProcess
       (_, _, _, p) <- createProcess (proc "sleep" ["0.1"])
       me1 <- newEmptyMVar
-      forkIO . void $ waitForProcess p >>= putMVar me1
+      _ <- forkIO . void $ waitForProcess p >>= putMVar me1
       -- check for race / deadlock between waitForProcess and getProcessExitCode
       e3 <- getProcessExitCode p
       e2 <- waitForProcess p
       e1 <- readMVar me1
-      unless (isNothing e3 && e1 == ExitSuccess && e2 == ExitSuccess)
+      unless (isNothing e3)
+            $ error $ "unexpected exit " ++ show e3
+      unless (e1 == ExitSuccess && e2 == ExitSuccess)
             $ error "sleep exited with non-zero exit code!"
 
     putStrLn "Tests passed successfully"


### PR DESCRIPTION
Previously an exception was being thrown when multiple threads were
blocking on waitForProcess due to inconsistent handling of the return
code of `waitpid`:

"If more than one thread is suspended in waitpid() awaiting termination
of the same process, exactly one thread returns the process status at
the time of the target child process termination. The other threads
return -1, with errno set to ECHILD."

`getProcessExitCode` was handling the ECHILD case by returning 1, but
`waitForProcess` was returning (-1) in all cases. For consistency this
commit follows the approach in getProcessExitCode, returning 1 to the
caller of c_waitForProcess if errno is ECHILD, thus avoiding throwing
an exception in the calling code.

Fixes #46

(An alternative fix could protect all calls to waitpid with an MVar, thus avoiding ECHILD altogether. I ended up settling on this fix because it follows the style in the rest of the library and fixes the bug with minimal code change.)
