### PR TITLE
Issue #59: added CreateBinaryPipe constructor to StdStream.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,20 +36,20 @@ matrix:
     compiler: ": #GHC 7.10.3"
     addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack GHCVER=7.8.4
-    compiler: ": #stack 7.8.4"
+  - env: BUILD=stack LTS_HASKELL_VER=2.22
+    compiler: ": #stack lts-2.22"
     addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack GHCVER=7.10.3
-    compiler: ": #stack 7.10.3"
+  - env: BUILD=stack LTS_HASKELL_VER=5.14
+    compiler: ": #stack lts-5.14"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack GHCVER=7.8.4
-    compiler: ": #stack 7.8.4 osx"
+  - env: BUILD=stack LTS_HASKELL_VER=2.22
+    compiler: ": #stack lts-2.22 osx"
     os: osx
 
-  - env: BUILD=stack GHCVER=7.10.3
-    compiler: ": #stack 7.10.3 osx"
+  - env: BUILD=stack LTS_HASKELL_VER=5.14
+    compiler: ": #stack lts-5.14 osx"
     os: osx
 
   - env: BUILD=cabal GHCVER=head  CABALVER=head
@@ -57,11 +57,16 @@ matrix:
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head
-  - env: BUILD=stack GHCVER=7.8.4
+  - env: BUILD=stack LTS_HASKELL_VER=2.22
 
 before_install:
  - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH
+ - case "$BUILD" in
+     stack)
+       export PATH=$HOME/.local/bin:$PATH;;
+     cabal)
+       export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH;;
+   esac
  - mkdir -p ~/.local/bin
  - if [ `uname` = "Darwin" ];
    then
@@ -71,14 +76,14 @@ before_install:
    fi
 
 install:
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - autoreconf -i
  - |
    case "$BUILD" in
      stack)
-       echo "resolver: ghc-$GHCVER" > stack.yaml;
+       echo "resolver: lts-$LTS_HASKELL_VER" > stack.yaml;
        stack --no-terminal --install-ghc test --only-dependencies;;
      cabal)
+       echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]";
        cabal --version;
        travis_retry cabal update;
        rm -f $(stack path --dist-dir)/stack-*.tar.gz;

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -150,9 +150,9 @@ needed.
 'createProcess' returns @(/mb_stdin_hdl/, /mb_stdout_hdl/, /mb_stderr_hdl/, /ph/)@,
 where
 
- * if @'std_in' == 'CreatePipe'@, then @/mb_stdin_hdl/@ will be @Just /h/@,
-   where @/h/@ is the write end of the pipe connected to the child
-   process's @stdin@.
+ * if 'std_in' is equal to 'CreatePipe' or 'CreateBinaryPipe',
+   then @/mb_stdin_hdl/@ will be @Just /h/@, where @/h/@ is the
+   write end of the pipe connected to the child process's @stdin@.
 
  * otherwise, @/mb_stdin_hdl/ == Nothing@
 

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -140,6 +140,9 @@ data StdStream
                              -- @Handle@ will use the default encoding
                              -- and newline translation mode (just
                              -- like @Handle@s created by @openFile@).
+  | CreateBinaryPipe         -- ^ Create a new pipe in binary mode
+                             -- (like @Handle@s created by
+                             -- @openBinaryFile@).
   | NoStream                 -- ^ No stream handle will be passed
 
 -- ----------------------------------------------------------------------------
@@ -179,6 +182,7 @@ fd_stderr = 2
 
 mbFd :: String -> FD -> StdStream -> IO FD
 mbFd _   _std CreatePipe      = return (-1)
+mbFd _   _std CreateBinaryPipe = return (-1)
 mbFd _fun std Inherit         = return std
 mbFd _fn _std NoStream        = return (-2)
 mbFd fun _std (UseHandle hdl) =
@@ -195,11 +199,12 @@ mbFd fun _std (UseHandle hdl) =
                    `ioeSetErrorString` "handle is not a file descriptor")
 
 mbPipe :: StdStream -> Ptr FD -> IOMode -> IO (Maybe Handle)
-mbPipe CreatePipe pfd  mode = fmap Just (pfdToHandle pfd mode)
+mbPipe CreatePipe pfd  mode = fmap Just (pfdToHandle pfd mode False)
+mbPipe CreateBinaryPipe pfd  mode = fmap Just (pfdToHandle pfd mode True)
 mbPipe _std      _pfd _mode = return Nothing
 
-pfdToHandle :: Ptr FD -> IOMode -> IO Handle
-pfdToHandle pfd mode = do
+pfdToHandle :: Ptr FD -> IOMode -> Bool -> IO Handle
+pfdToHandle pfd mode binary = do
   fd <- peek pfd
   let filepath = "fd:" ++ show fd
   (fD,fd_type) <- FD.mkFD (fromIntegral fd) mode
@@ -207,9 +212,14 @@ pfdToHandle pfd mode = do
                        False {-is_socket-}
                        False {-non-blocking-}
   fD' <- FD.setNonBlockingMode fD True -- see #3316
+  -- Choose either text or binary mode (cf. GHC.IO.Handle.FD.openFile').
 #if __GLASGOW_HASKELL__ >= 704
-  enc <- getLocaleEncoding
+  mb_enc <- if binary
+            then return Nothing
+            else fmap Just getLocaleEncoding
 #else
-  let enc = localeEncoding
+  let mb_enc = if binary
+               then Nothing
+               else Just localeEncoding
 #endif
-  mkHandleFromFD fD' fd_type filepath mode False {-is_socket-} (Just enc)
+  mkHandleFromFD fD' fd_type filepath mode False {-is_socket-} mb_enc

--- a/process.cabal
+++ b/process.cabal
@@ -78,3 +78,10 @@ test-suite test
   type: exitcode-stdio-1.0
   build-depends: base
                , process
+
+test-suite test-binary
+  default-language: Haskell2010
+  hs-source-dirs: test
+  main-is: test-binary.hs
+  type: exitcode-stdio-1.0
+  build-depends: base, process, HUnit, deepseq

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: ghc-7.10.2
+resolver: lts-5.14

--- a/test/test-binary.hs
+++ b/test/test-binary.hs
@@ -1,0 +1,64 @@
+-- Test suite for binary I/O.
+
+import System.Process
+
+import Test.HUnit
+import Control.Monad
+import System.IO
+import System.Exit
+import Control.Exception (evaluate)
+import Control.DeepSeq (rnf)
+
+
+data StreamMode = TextMode | BinaryMode
+
+pipeSpec :: StreamMode -> StdStream
+pipeSpec TextMode = CreatePipe
+pipeSpec BinaryMode = CreateBinaryPipe
+
+testCreateProcessCat :: String -- name of this test case
+                     -> StreamMode -- stdin
+                     -> StreamMode -- stdout
+                     -> String -- stdin
+                     -> String -- expected stdout
+                     -> Assertion
+testCreateProcessCat name modeIn modeOut xIn xOut = do
+  (Just hIn, Just hOut, Nothing, ph) <- createProcess
+    (proc "cat" []){ std_in = pipeSpec modeIn,
+                     std_out = pipeSpec modeOut }
+  hPutStr hIn xIn
+  hClose hIn
+  xOut2 <- hGetContents hOut
+  evaluate (rnf xOut2)
+  hClose hOut
+  exitCode <- waitForProcess ph
+  assertEqual name (exitCode, xOut2) (ExitSuccess, xOut)
+
+someString = "a\xf0\x1003\&b"
+someStringUtf8 = "a\195\176\225\128\131b"
+someStringTrunc = "a\xf0\x03\&b"
+
+testSuite :: Test
+testSuite = TestList . map TestCase $
+  [testCreateProcessCat "testCreateProcessCat1"
+     TextMode TextMode someString someString
+   -- In binary mode, characters are truncated to 8-bits
+   -- (c.f. documentation for 'hSetBinaryMode').
+  ,testCreateProcessCat "testCreateProcessCat2"
+     BinaryMode BinaryMode someString someStringTrunc
+  ]
+  ++
+  -- The following tests are only valid in the utf-8 locale.
+  (if show localeEncoding == "UTF-8"
+   then [testCreateProcessCat "testCreateProcessCat3"
+           TextMode BinaryMode someString someStringUtf8
+        ,testCreateProcessCat "testCreateProcessCat4"
+           BinaryMode TextMode someStringUtf8 someString
+        ]
+   else [])
+
+main :: IO ()
+main = do
+  r <- runTestTT testSuite
+  when (errors r > 0 || failures r > 0) $
+    exitFailure


### PR DESCRIPTION
CreateBinaryPipe is to CreatePipe as openBinaryFile is to
openFile. See Process/Common.hs for the implementation.

I also added a test suite (test-binary.hs). I had to change the
stack resolver from ghc to lts in order to allow an HUnit
dependency.
