### PR TITLE
Close pipes on failure

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -84,6 +84,10 @@ runInteractiveProcess (char *const args[],
     if (fdStdOut == -1) {
         r = pipe(fdStdOutput);
         if (r == -1) {
+            if (fdStdIn == -1) {
+                close(fdStdInput[0]);
+                close(fdStdInput[1]);
+            }
             *failed_doing = "runInteractiveProcess: pipe";
             return -1;
         }
@@ -92,6 +96,14 @@ runInteractiveProcess (char *const args[],
         r = pipe(fdStdError);
         if (r == -1) {
             *failed_doing = "runInteractiveProcess: pipe";
+            if (fdStdIn == -1) {
+                close(fdStdInput[0]);
+                close(fdStdInput[1]);
+            }
+            if (fdStdOut == -1) {
+                close(fdStdOutput[0]);
+                close(fdStdOutput[1]);
+            }
             return -1;
         }
     }
@@ -327,6 +339,19 @@ runInteractiveProcess (char *const args[],
         // We forked the child, but the child had a problem and stopped so it's
         // our responsibility to reap here as nobody else can.
         waitpid(pid, NULL, 0);
+
+        if (fdStdIn == -1) {
+            close(fdStdInput[0]);
+            close(fdStdInput[1]);
+        }
+        if (fdStdOut == -1) {
+            close(fdStdOutput[0]);
+            close(fdStdOutput[1]);
+        }
+        if (fdStdErr == -1) {
+            close(fdStdError[0]);
+            close(fdStdError[1]);
+        }
 
         pid = -1;
     }


### PR DESCRIPTION
Make sure stdin, stdout and stderr pipes are closed when exec call
fails, e.g. when the executable doesn't exist.

It is an attempt to fix #64. The code around is pretty complicated, I'm not 100% sure I'm doing everything right, so please review carefully. Anyway, it fixes the immediate issue I had in my application.