### PR TITLE
Expose withCreateProcess to users.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## Unreleased
+
+  * New exposed `withCreateProcess`
+
 ## 1.4.2.0 *January 2016*
 
 * Added `createPipeFD` [#52](https://github.com/haskell/process/pull/52)


### PR DESCRIPTION
The function was commented out and not used anywhere.

It's currently rather cumbersome to run a process in the background, perform some action, and close the process once your action is completed. I believe withCreateProcess can handle that use-case and just wasn't exposed.