### PR TITLE
Fix CPP usage

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -50,7 +50,7 @@ import System.Posix.Internals (FD)
 
 import System.Process.Common
 
-#if WINDOWS
+#ifdef WINDOWS
 import System.Process.Windows
 #else
 import System.Process.Posix


### PR DESCRIPTION
The code `#if WINDOWS` works but is not really correct. GHC HEAD now
has a `-Wcpp-undef` warning that we would like to turn on and hence
need this fixed.