### PR TITLE
Don't close already closed pipes 

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -161,7 +161,7 @@ runInteractiveProcess (char *const args[],
         if ((flags & RUN_PROCESS_IN_NEW_GROUP) != 0) {
             setpgid(0, 0);
         }
-        
+
         if ( childGroup) {
             if ( setgid( *childGroup) != 0) {
                 // ERROR
@@ -240,9 +240,9 @@ runInteractiveProcess (char *const args[],
             }
             // XXX Not the pipe
             for (i = 3; i < max_fd; i++) {
-		if (i != forkCommunicationFds[1]) {
-		    close(i);
-		}
+                if (i != forkCommunicationFds[1]) {
+                    close(i);
+                }
             }
         }
 

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -341,16 +341,16 @@ runInteractiveProcess (char *const args[],
         waitpid(pid, NULL, 0);
 
         if (fdStdIn == -1) {
-            close(fdStdInput[0]);
+            // Already closed fdStdInput[0] above
             close(fdStdInput[1]);
         }
         if (fdStdOut == -1) {
             close(fdStdOutput[0]);
-            close(fdStdOutput[1]);
+            // Already closed fdStdOutput[1] above
         }
         if (fdStdErr == -1) {
             close(fdStdError[0]);
-            close(fdStdError[1]);
+            // Already closed fdStdError[1] above
         }
 
         pid = -1;


### PR DESCRIPTION
a9a8e91 added some `close` calls which attempted to close pipes that we already closed previously. This resulted in the error code we read from the failed child being overwritten, resulting in the `process004` test failing.