### PR TITLE
Relax Win32 version bounds.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Bug fix: Don't close already closed pipes
   [#81](https://github.com/haskell/process/pull/81)
+* Relax version bounds of Win32 to allow 2.5.
 
 ## 1.4.3.0 *December 2016*
 

--- a/process.cabal
+++ b/process.cabal
@@ -50,7 +50,7 @@ library
     other-modules: System.Process.Common
     if os(windows)
         other-modules: System.Process.Windows
-        build-depends: Win32 >=2.2 && < 2.4
+        build-depends: Win32 >=2.2 && < 2.6
         extra-libraries: kernel32
         cpp-options: -DWINDOWS
     else


### PR DESCRIPTION
I'd like to deploy Win32 2.5 with GHC 8.4 but the version bounds on Directory are currently preventing this. As such I'd like to bump the bounds in Directory as well.

The release log for 2.5 is here https://github.com/haskell/win32/releases/tag/v2.5.0.0