### PR TITLE
Re-export CGid and friends from System.Process.Internals

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -9,6 +9,8 @@ module System.Process.Common
     , ProcRetHandles (..)
     , withFilePathException
     , PHANDLE
+    , GroupID
+    , UserID
     , modifyProcessHandle
     , withProcessHandle
     , fd_stdin

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -22,6 +22,13 @@
 module System.Process.Internals (
     ProcessHandle(..), ProcessHandle__(..),
     PHANDLE, closePHANDLE, mkProcessHandle,
+#ifdef WINDOWS
+    CGid(..),
+#else
+    CGid,
+#endif
+    GroupID,
+    UserID,
     modifyProcessHandle, withProcessHandle,
     CreateProcess(..),
     CmdSpec(..), StdStream(..), ProcRetHandles (..),

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+* Expose `CGid`, `GroupID`, and `UserID` from `System.Process.Internals`
+  [#90](https://github.com/haskell/process/issues/90)
+  [#91](https://github.com/haskell/process/pull/91)
+
 ## 1.6.0.0 *February 2017*
 
 * Fix: waitForProcess race condition


### PR DESCRIPTION
This re-exports `CGid` (which was previously unusable on Windows due to its unavailability) from `System.Process.Internals`. It also re-exports the synonyms `GroupID` and `UserID` so that the Haddocks will have a place to point to on Windows.

Fixes #90.