### PR TITLE
System.Process.Posix: Hide mb_delegate_ctlc

### DIFF
--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -40,7 +40,7 @@ import System.Posix.Signals as Sig
 import qualified System.Posix.IO as Posix
 import System.Posix.Process (getProcessGroupIDOf)
 
-import System.Process.Common
+import System.Process.Common hiding (mb_delegate_ctlc)
 
 #include "HsProcessConfig.h"
 #include "processFlags.h"


### PR DESCRIPTION
As it is shadowed by other local bindings in this module.

It turns out this is necessary afterall.