### PR TITLE
Export withCreateProcess documentation

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -199,7 +199,6 @@ createProcess cp = do
     | hdl /= stdin && hdl /= stdout && hdl /= stderr = hClose hdl
   maybeCloseStd _ = return ()
 
-{-
 -- | A 'C.bracket'-style resource handler for 'createProcess'.
 --
 -- Does automatic cleanup when the action finishes. If there is an exception
@@ -214,7 +213,6 @@ createProcess cp = do
 -- >   ...
 --
 -- @since 1.4.3.0
--}
 withCreateProcess
   :: CreateProcess
   -> (Maybe Handle -> Maybe Handle -> Maybe Handle -> ProcessHandle -> IO a)


### PR DESCRIPTION
The function is public, but the Haddock documentation isn't being rendered. I think it's a simple matter of removing the `{-` and `-}`, but I haven't tested locally.

Example render of missing documentation:

<img width="1404" alt="screen shot 2017-05-22 at 16 38 01" src="https://cloud.githubusercontent.com/assets/125674/26316705/0ee0b58a-3f0d-11e7-94bc-1f48d56d8eb0.png">

(from http://hackage.haskell.org/package/process-1.6.0.0/docs/System-Process.html)