### PR TITLE
Allow async exceptions to pierce masked waitForProcess

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -77,7 +77,7 @@ import System.Process.Internals
 
 import Control.Concurrent
 import Control.DeepSeq (rnf)
-import Control.Exception (SomeException, mask, bracket, try, throwIO)
+import Control.Exception (SomeException, mask, allowInterrupt, bracket, try, throwIO)
 import qualified Control.Exception as C
 import Control.Monad
 import Data.Maybe
@@ -589,7 +589,7 @@ waitForProcess ph@(ProcessHandle _ delegating_ctlc _) = lockWaitpid $ do
     OpenHandle h  -> do
         e <- alloca $ \pret -> do
           -- don't hold the MVar while we call c_waitForProcess...
-          throwErrnoIfMinus1Retry_ "waitForProcess" (c_waitForProcess h pret)
+          throwErrnoIfMinus1Retry_ "waitForProcess" (allowInterrupt >> c_waitForProcess h pret)
           modifyProcessHandle ph $ \p_' ->
             case p_' of
               ClosedHandle e  -> return (p_', e)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+* Allow async exceptions to be delivered to masked thread calling `waitForProcess`
+  [#101](https://github.com/haskell/process/pull/101)
+
 ## 1.6.1.0 *July 2017*
 
 * Expose `CGid`, `GroupID`, and `UserID` from `System.Process.Internals`


### PR DESCRIPTION
Hello!

I believe I found a bug in `waitForProcess`. When run in the `MaskedInterruptible` state, an async exception doesn't actually bring the thread down.

For example, the `typed-process` library exports [`withProcess`](https://hackage.haskell.org/package/typed-process-0.1.0.0/docs/System-Process-Typed.html#v:withProcess) which is similar to [`withCreateProcess`](https://hackage.haskell.org/package/process-1.6.1.0/docs/System-Process.html#v:withCreateProcess), but ends up calling `waitForProcess` in the cleanup action of a `bracket`.

Even though `waitForProcess` is an `interruptible` foreign call, I think what's happening is:

- Async exception enqueued for delivery to thread making `waitForProcess` call
- GHC sees it's in an `interruptible` foreign call, sends `SIGPIPE` ([GHC docs](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/ffi-chap.html#interruptible-foreign-calls))
- [`c_waitForProcess`](https://github.com/haskell/process/blob/c3ab2ccac5972ef23e0727d3c016652e9cda0d1f/System/Process.hs#L592) returns `-1` with errno = `EINTR`
- Upon returning to Haskell, the pending exception is _not_ delivered, because the masking state is `MaskedInterruptible`
- `c_waitForProcess` is retried because it's wrapped by `throwErrnoIfMinus1Retry_`

So our "interruptible" `waitForProcess` is only half-interrupted :)

My fix in this patch is to simply poll for any async exceptions before entering `c_waitForProcess`. [Here](https://github.com/fpco/typed-process/pull/2) is some related discussion I had with @snoyberg.

Thanks!