### PR TITLE
Improve documentation of withCreateProcess

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -209,7 +209,7 @@ createProcess cp = do
 --
 -- e.g.
 --
--- > withCreateProcess (proc cmd args) { ... }  $ \_ _ _ ph -> do
+-- > withCreateProcess (proc cmd args) { ... }  $ \stdin stdout stderr ph -> do
 -- >   ...
 --
 -- @since 1.4.3.0


### PR DESCRIPTION
Previously it was not entirely obvious which handle corresponds to
stdin, stdout and stderr.