### PR TITLE
Bump Win32 constraint up for GHC 8.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Allow async exceptions to be delivered to masked thread calling `waitForProcess`
   [#101](https://github.com/haskell/process/pull/101)
+* Update Win32 package version to 2.6.x
 
 ## 1.6.1.0 *July 2017*
 

--- a/process.cabal
+++ b/process.cabal
@@ -56,7 +56,7 @@ library
     other-modules: System.Process.Common
     if os(windows)
         other-modules: System.Process.Windows
-        build-depends: Win32 >=2.2 && < 2.6
+        build-depends: Win32 >=2.2 && < 2.7
         extra-libraries: kernel32
         cpp-options: -DWINDOWS
     else


### PR DESCRIPTION
Hi,

I'd like to bump up the Win32 version for GHC 8.4.

Win32 2.6 contains API breaking changes but those APIs aren't used by process.
