### PR TITLE
Added getPid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+## 1.6.3.0 *November 2017*
+
+* Added `getPid` and export of platform specific `Pid` type
+  [#109](https://github.com/haskell/process/pull/109)
+
 ## 1.6.2.0 *October 2017*
 
 * Allow async exceptions to be delivered to masked thread calling `waitForProcess`


### PR DESCRIPTION
This implements my request #108

Tested on Linux and Windows. For Linux i used "stack test". For windows i did a seperate manual test (compared the PID with the info from the Task-Manger). The test/main.hs does not look like it could be run on Windows (for example echo is a builtin of cmd.exe and not a program on its own).

On Windows the PID stays valid as long as the handle is open (see https://blogs.msdn.microsoft.com/oldnewthing/20110107-00/?p=11803).