### PR TITLE
Process: fix flaky test.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,3 +10,6 @@ include $(TOP)/mk/test.mk
 process007_fd:
 	'$(TEST_HC)' -optc='-Wall' -no-hs-main -no-auto-link-packages process007_fd.c -o process007_fd
 
+.PHONY: T3994app
+T3994app:
+	'$(TEST_HC)' $(TEST_HC_OPTS) T3994app.hs -threaded

--- a/tests/T3994.hs
+++ b/tests/T3994.hs
@@ -5,7 +5,7 @@ import System.IO
 import System.Process
 
 main :: IO ()
-main = do (_,Just hout,_,p) <- createProcess (proc "sh" ["-c", "echo start; sleep 10"])
+main = do (_,Just hout,_,p) <- createProcess (proc "T3994app" ["start", "10000"])
                             { std_out = CreatePipe, create_group = True }
           start <- hGetLine hout
           putStrLn start

--- a/tests/T3994app.hs
+++ b/tests/T3994app.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import Control.Concurrent
+import System.Environment
+
+main :: IO ()
+main = do (str:time:_) <- getArgs
+          putStrLn str
+          threadDelay (read time)
+          return ()

--- a/tests/all.T
+++ b/tests/all.T
@@ -27,7 +27,10 @@ test('T4198',
      compile_and_run,
      [''])
 
-test('T3994', only_ways(['threaded1','threaded2']), compile_and_run, [''])
+test('T3994', [only_ways(['threaded1','threaded2']),
+               extra_files(['T3994app.hs']),
+               pre_cmd('$MAKE -s --no-print-directory T3994app')],
+     compile_and_run, [''])
 test('T4889', normal, compile_and_run, [''])
 
 test('process009', when(opsys('mingw32'), skip), compile_and_run, [''])


### PR DESCRIPTION
Calling `sh` and `sleep` can be quite flacky on Windows due to the msys2 runtime. 

It can result in random failures such as:

```
+      6 [main] sh 22832 child_copy: cygheap read copy failed, 0x1802F6408..0x1802FF298, done 0, windows pid 22832, Win32 error 299
+  16044 [main] sh 22832 C:/msys64/usr/bin/sh: *** fatal error in forked process - ccalloc would have returned NULL
```

So about that by using a Haskell program that does the same action. This makes the test stable again under Windows.