### PR TITLE
Process: fix linux test build.

### DIFF
--- a/tests/T3994.hs
+++ b/tests/T3994.hs
@@ -5,7 +5,7 @@ import System.IO
 import System.Process
 
 main :: IO ()
-main = do (_,Just hout,_,p) <- createProcess (proc "T3994app" ["start", "10000"])
+main = do (_,Just hout,_,p) <- createProcess (proc "./T3994app" ["start", "10000"])
                             { std_out = CreatePipe, create_group = True }
           start <- hGetLine hout
           putStrLn start


### PR DESCRIPTION
Previous PR broke the test under Linux and MacOS due to the new binary not being on the `PATH`.

This version seems to work on Linux and Windows. Excuse the noise :(