### PR TITLE
Close pipes on failure

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -111,6 +111,18 @@ runInteractiveProcess (char *const args[],
     r = pipe(forkCommunicationFds);
     if (r == -1) {
         *failed_doing = "runInteractiveProcess: pipe";
+        if (fdStdIn == -1) {
+            close(fdStdInput[0]);
+            close(fdStdInput[1]);
+        }
+        if (fdStdOut == -1) {
+            close(fdStdOutput[0]);
+            close(fdStdOutput[1]);
+        }
+        if (fdStdErr == -1) {
+            close(fdStdError[0]);
+            close(fdStdError[1]);
+        }
         return -1;
     }
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+* Bug fix: Don't leak pipes on failure
+  [#122](https://github.com/haskell/process/issues/122)
+
 ## 1.6.3.0 *January 2018*
 
 * Added `getPid` and export of platform specific `Pid` type


### PR DESCRIPTION
When we fail to create communication pipe, we should cleanup resources
before exit. E.g. we should close pipes for stdin, stdout and stderr if
they where created. Fixes #122.