### PR TITLE
Bump upper bound on unix to < 2.9

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -61,7 +61,7 @@ library
         cpp-options: -DWINDOWS
     else
         other-modules: System.Process.Posix
-        build-depends: unix >= 2.5 && < 2.8
+        build-depends: unix >= 2.5 && < 2.9
 
     c-sources:
         cbits/runProcess.c


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15042.