### PR TITLE
Import IOMode from System.IO instead of GHC.IO.IOMode

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -44,7 +44,7 @@ import GHC.IO.Handle.Internals
 import GHC.IO.Handle.Types hiding (ClosedHandle)
 import System.IO.Error
 import Data.Typeable
-import GHC.IO.IOMode
+import System.IO (IOMode)
 
 -- We do a minimal amount of CPP here to provide uniform data types across
 -- Windows and POSIX.

--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -34,7 +34,7 @@ import GHC.IO.Exception
 import GHC.IO.Handle.FD
 import GHC.IO.Handle.Types hiding (ClosedHandle)
 import System.IO.Error
-import GHC.IO.IOMode
+import System.IO (IOMode(..))
 
 import System.Directory         ( doesFileExist )
 import System.Environment       ( getEnv )


### PR DESCRIPTION
At some point we'd like to hide `GHC.IO.IOMode` from base. 

Related base change: https://phabricator.haskell.org/D4692