### PR TITLE
expose cleanupProcess

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -43,6 +43,7 @@ module System.Process (
     readCreateProcessWithExitCode,
     readProcessWithExitCode,
     withCreateProcess,
+    cleanupProcess,
 
     -- ** Related utilities
     showCommandForUser,
@@ -245,7 +246,10 @@ withCreateProcess_ fun c action =
     C.bracketOnError (createProcess_ fun c) cleanupProcess
                      (\(m_in, m_out, m_err, ph) -> action m_in m_out m_err ph)
 
-
+-- | Cleans up the process.
+-- 
+-- This function is meant to be invoked from any application level cleanup 
+-- handler. It terminates the process, and closes any 'CreatePipe' 'handle's.
 cleanupProcess :: (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
                -> IO ()
 cleanupProcess (mb_stdin, mb_stdout, mb_stderr,

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -250,6 +250,8 @@ withCreateProcess_ fun c action =
 -- 
 -- This function is meant to be invoked from any application level cleanup 
 -- handler. It terminates the process, and closes any 'CreatePipe' 'handle's.
+-- 
+-- @since 1.6.4.0
 cleanupProcess :: (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
                -> IO ()
 cleanupProcess (mb_stdin, mb_stdout, mb_stderr,

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 * Bug fix: Don't leak pipes on failure
   [#122](https://github.com/haskell/process/issues/122)
+* Expose `cleanupProcess` from `System.Process` 
+  [#130](https://github.com/haskell/process/pull/130)
 
 ## 1.6.3.0 *January 2018*
 


### PR DESCRIPTION
`cleanupProcess` needs to be exported in order to be able to write a version of `withCreateProcess` that works with MonadIO.