### PR TITLE
process00{1,2} tests: just assume `ls` is in the PATH on non-Windows systems

### DIFF
--- a/tests/process001.hs
+++ b/tests/process001.hs
@@ -2,15 +2,9 @@
 import System.IO
 import System.Process
 
-#ifdef mingw32_HOST_OS
-cmd = "ls"
-#else
-cmd = "/bin/ls"
-#endif
-
 test = do
   h <- openFile "process001.out" WriteMode
-  ph <- runProcess cmd [] Nothing Nothing Nothing (Just h) Nothing
+  ph <- runProcess "ls" [] Nothing Nothing Nothing (Just h) Nothing
   waitForProcess ph
 
 main = test >> test >> return ()

--- a/tests/process002.hs
+++ b/tests/process002.hs
@@ -2,14 +2,8 @@
 import System.Process
 import System.IO
 
-#ifdef mingw32_HOST_OS
-cmd = "ls"
-#else
-cmd = "/bin/ls"
-#endif
-
 main = do
   h <- openFile "process002.out" WriteMode
-  ph <- runProcess cmd [] Nothing Nothing Nothing (Just h) (Just h)
+  ph <- runProcess "ls" [] Nothing Nothing Nothing (Just h) (Just h)
   waitForProcess ph
   return ()


### PR DESCRIPTION
This should work on all the systems I've ever laid my hands on (not many, admittedly) and of particular interest to me and several other GHC/core libraries contributors who run GHC's testsuite, with this patch those tests now pass on NixOS.

``` sh
$ TEST="process001 process002" ./validate --fast --testsuite-only
[...]
==== STAGE 2 TESTS ==== 

SUMMARY for test run started at Tue Jun 12 15:51:02 2018 CEST
 0:00:01 spent to go through
       2 total tests, which gave rise to
      14 test cases, of which
      12 were skipped

       0 had missing libraries
       2 expected passes
       0 expected failures

       0 caused framework failures
       0 caused framework warnings
       0 unexpected passes
       0 unexpected failures
       0 unexpected stat failures
```

There, `ls` is not under `/bin` but somewhere in the nix store and brought into the PATH through symlinks in a "current environment" directory which itself _is_ in the PATH.