### PR TITLE
Add bounds on base in test-suite stanza

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -85,7 +85,7 @@ test-suite test
   hs-source-dirs: test
   main-is: main.hs
   type: exitcode-stdio-1.0
-  build-depends: base
+  build-depends: base >= 4 && < 5
                , bytestring
                , directory
                , process


### PR DESCRIPTION
GHC's build system runs `ghc-cabal check` on the cabal files for all of its
core libraries. One of the checks that this performs is to verify that base
has bounds. IMHO it's a bit silly that this is necessary even when base
is otherwise constrained by the library stanza so I've left the bounds
quite loose.