### PR TITLE
Call initgroups before setuid

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -329,6 +329,7 @@ runInteractiveProcess (char *const args[],
             break;
         case forkSetuidFailed:
             *failed_doing = "runInteractiveProcess: setuid";
+            break;
         default:
             *failed_doing = "runInteractiveProcess: unknown";
             break;

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Unreleased changes
 
+* Fix a potential privilege escalation issue (or, more precisely, privileges
+  not being dropped when this was the user's intent) where the groups of the
+  spawning process's user would be incorrectly retained due to a missing call to
+  `initgroups` [#149].
+
 ## 1.6.5.1 *June 2019*
 
 * Version bound bumps

--- a/include/runProcess.h
+++ b/include/runProcess.h
@@ -21,6 +21,10 @@
 
 #include <unistd.h>
 #include <sys/types.h>
+#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32))
+#include <pwd.h>
+#include <grp.h>
+#endif
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>


### PR DESCRIPTION
This fixes a potential privilege escalation issue (or, more precisely, privileges not being dropped when this was the user's intent) where the groups of the spawning process's user would be incorrectly retained due to a missing call to `initgroups`.

This also fixes an incorrect case fallthrough in the error message lookup logic.

Fixes #149.