### PR TITLE
use withFilePath for environment variables

### DIFF
--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -93,7 +93,7 @@ translateInternal str
 withCEnvironment :: [(String,String)] -> (Ptr CString  -> IO a) -> IO a
 withCEnvironment envir act =
   let env' = map (\(name, val) -> name ++ ('=':val)) envir
-  in withMany withCString env' (\pEnv -> withArray0 nullPtr pEnv act)
+  in withMany withFilePath env' (\pEnv -> withArray0 nullPtr pEnv act)
 
 -- -----------------------------------------------------------------------------
 -- POSIX runProcess with signal handling in the child

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@
   not being dropped when this was the user's intent) where the groups of the
   spawning process's user would be incorrectly retained due to a missing call to
   `initgroups` [#149].
+* Bug fix: Prevent stripping undecodable bytes from environment variables
+  when in a non-unicode locale.
+  [#152](https://github.com/haskell/process/issues/152)
 
 ## 1.6.5.1 *June 2019*
 


### PR DESCRIPTION
withCString doesn't allow undecodable bytes to round-trip through the
program, so use withFilePath to pack the environment. (It was already
used for packing the arguments.)

Closes https://github.com/haskell/process/issues/152