### PR TITLE
Export runInteractiveProcess_lock on Posix systems

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -46,6 +46,7 @@ module System.Process.Internals (
 #else
     pPrPr_disableITimers, c_execvpe,
     ignoreSignal, defaultSignal,
+    runInteractiveProcess_lock,
 #endif
     withFilePathException, withCEnvironment,
     translate,

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -17,6 +17,7 @@ module System.Process.Posix
     , createPipeInternal
     , createPipeInternalFd
     , interruptProcessGroupOfInternal
+    , runInteractiveProcess_lock
     ) where
 
 import Control.Concurrent

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -179,6 +179,8 @@ createProcess_Internal fun
 -- (and also need to make the same global state changes) can protect their changes
 -- with the same lock.
 -- See https://github.com/haskell/process/pull/154.
+--
+-- @since 1.6.6.0
 runInteractiveProcess_lock :: MVar ()
 runInteractiveProcess_lock = unsafePerformIO $ newMVar ()
 

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -139,10 +139,7 @@ createProcess_Internal fun
      when mb_delegate_ctlc
        startDelegateControlC
 
-     -- runInteractiveProcess() blocks signals around the fork().
-     -- Since blocking/unblocking of signals is a global state
-     -- operation, we better ensure mutual exclusion of calls to
-     -- runInteractiveProcess().
+     -- See the comment on runInteractiveProcess_lock
      proc_handle <- withMVar runInteractiveProcess_lock $ \_ ->
                          c_runInteractiveProcess pargs pWorkDir pEnv
                                 fdin fdout fderr
@@ -175,6 +172,13 @@ createProcess_Internal fun
                            }
 
 {-# NOINLINE runInteractiveProcess_lock #-}
+-- | 'runInteractiveProcess' blocks signals around the fork().
+-- Since blocking/unblocking of signals is a global state operation, we need to
+-- ensure mutual exclusion of calls to 'runInteractiveProcess'.
+-- This lock is exported so that other libraries which also need to fork()
+-- (and also need to make the same global state changes) can protect their changes
+-- with the same lock.
+-- See https://github.com/haskell/process/pull/154.
 runInteractiveProcess_lock :: MVar ()
 runInteractiveProcess_lock = unsafePerformIO $ newMVar ()
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
-## Unreleased changes
+## 1.6.5.2 *September 2019*
 
 * Fix a potential privilege escalation issue (or, more precisely, privileges
   not being dropped when this was the user's intent) where the groups of the
@@ -9,6 +9,8 @@
 * Bug fix: Prevent stripping undecodable bytes from environment variables
   when in a non-unicode locale.
   [#152](https://github.com/haskell/process/issues/152)
+* Expose `runInteractiveProcess_lock` in `System.Process.Internals`
+  [#154](https://github.com/haskell/process/pull/154)
 
 ## 1.6.5.1 *June 2019*
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
-## 1.6.5.2 *September 2019*
+## 1.6.6.0 *September 2019*
 
 * Fix a potential privilege escalation issue (or, more precisely, privileges
   not being dropped when this was the user's intent) where the groups of the


### PR DESCRIPTION
This PR is to help fix https://github.com/merijn/posix-pty/issues/15. 

Summary: on Posix systems, `System.Process` must take certain precautions before using the `fork` system call. These include altering global state by calling `blockUserSignals` and `stopTimer()` before forking; see https://github.com/haskell/process/blob/master/cbits/runProcess.c#L137.

However, `System.Process` is not the only library that might need to use fork. `System.Posix.Pty` is another such library -- it uses the `forkpty` call (which internally does `fork`) to create a process attached to a pseudo-terminal. Thus System.Posix.Pty also needs to take these precautions.

As a result, we need to ensure mutual exclusion between `System.Posix.Pty` fork calls and `System.Process` fork calls, or else they stomp on each other's changes to global state. The only way I can see to do this is to use the same lock, so this PR exports it. I made a PR on `posix-pty` to leverage it here: https://github.com/merijn/posix-pty/pull/16.

Of course, this feels like a bit of a band-aid since it only ensures that interleaving these two libraries is safe. Other libraries that might want to `fork` will still run into problems interleaving with these libraries. It would be nice to get some GHC expert attention on this but maybe that's an issue for another tracker.
