### PR TITLE
Windows: Check if all processes really exited and released resources

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -903,7 +903,8 @@ waitForJobCompletion ( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode
     // List of events we can listen to:
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684141(v=vs.85).aspx
     while (GetQueuedCompletionStatus (ioPort, &CompletionCode,
-           &CompletionKey, &Overlapped, timeout)) {
+                                      &CompletionKey, &Overlapped, timeout)
+           && (HANDLE)CompletionKey == hJob) {
 
         switch (CompletionCode)
         {
@@ -930,6 +931,10 @@ waitForJobCompletion ( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode
                     maperrno();
                     return 1;
                 }
+
+                // Check to see if the child has actually exited.
+                if (*(DWORD *)pExitCode == STILL_ACTIVE)
+                  waitForProcess ((ProcHandle)pHwnd, pExitCode);
             }
             break;
             case JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO:

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+* Fix a race condition on Windows that happens when you use process jobs and one of
+  the child processes terminates but doesn't release its resources immediately.
+  Control returns to the caller too soon in this scenario. See [#159](https://github.com/haskell/process/pull/159)
+
 ## 1.6.6.0 *October 2019*
 
 * Fix a potential privilege escalation issue (or, more precisely, privileges
@@ -29,7 +33,7 @@
 
 * Bug fix: Don't leak pipes on failure
   [#122](https://github.com/haskell/process/issues/122)
-* Expose `cleanupProcess` from `System.Process` 
+* Expose `cleanupProcess` from `System.Process`
   [#130](https://github.com/haskell/process/pull/130)
 * Drop support for GHC before 7.10.3
 


### PR DESCRIPTION
The PR makes sure we're only listening to completion events for the `key` that we're interested in. This isn't much of an issue now but the new I/O manager for Windows will exclusively use I/O completion ports. Which means this method may mistakenly handle events it shouldn't have.

Secondly it fixes a rare but annoying condition. When you receive a notification on the port that a process has terminated this does not mean that the resources of the process has been flushed.

Previously we were immediately unregister the process once we get the notification. However things like `hsc2hs` which rely on the child process having written a file then may get into a race condition. Control may return to the caller before the file has actually been written.

Windows deals with this by returning an exit code `STILL_ACTIVE` which is to be interpreted as `"process has exited but has not yet been cleaned up"`.  If we get such an event we then block and wait for the OS to signal the handle and re-set the exit code.

This fixes https://gitlab.haskell.org/ghc/ghc/issues/17108 and https://gitlab.haskell.org/ghc/ghc/issues/17249