### PR TITLE
Don't exit when even isn't ours

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -903,8 +903,11 @@ waitForJobCompletion ( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode
     // List of events we can listen to:
     // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684141(v=vs.85).aspx
     while (GetQueuedCompletionStatus (ioPort, &CompletionCode,
-                                      &CompletionKey, &Overlapped, timeout)
-           && (HANDLE)CompletionKey == hJob) {
+                                      &CompletionKey, &Overlapped, timeout)) {
+
+        // If event wasn't meant of us, keep listening.
+        if ((HANDLE)CompletionKey != hJob)
+          continue;
 
         switch (CompletionCode)
         {


### PR DESCRIPTION
Sorry, just noticed that in #159 it would exit the event loop if the event isn't ours.

It should continue listening not abort. This is mostly dead code till GHC 8.12 when there will be multiple events and event queues. 