### PR TITLE
Changed "\home\bob" to "/home/bob" in docs for System.Process.createProcess

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -188,7 +188,7 @@ To create a pipe from which to read the output of @ls@:
 To also set the directory in which to run @ls@:
 
 >   (_, Just hout, _, _) <-
->       createProcess (proc "ls" []){ cwd = Just "\home\bob",
+>       createProcess (proc "ls" []){ cwd = Just "/home/bob",
 >                                     std_out = CreatePipe }
 
 Note that @Handle@s provided for @std_in@, @std_out@, or @std_err@ via the


### PR DESCRIPTION
"\home\bob" does not form valid Haskell as there is no "\h" character.
Therefore, this line was changed to the *nix directory location it was intended
to be.

This closes #165.