### PR TITLE
Fix job support

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -186,8 +186,15 @@ data StdStream
      completion. This requires two handles. A process job handle and
      a events handle to monitor.
 -}
-data ProcessHandle__ = OpenHandle PHANDLE
-                     | OpenExtHandle PHANDLE PHANDLE PHANDLE
+data ProcessHandle__ = OpenHandle { phdlProcessHandle :: PHANDLE }
+                     | OpenExtHandle { phdlProcessHandle :: PHANDLE
+                                     -- ^ the process
+                                     , phdlJobHandle     :: PHANDLE
+                                     -- ^ the job containing the process and
+                                     -- its subprocesses
+                                     , phdlIocpHandle    :: PHANDLE
+                                     -- ^ the job's IO Completion Port
+                                     }
                      | ClosedHandle ExitCode
 data ProcessHandle
   = ProcessHandle { phandle          :: !(MVar ProcessHandle__)

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -192,8 +192,6 @@ data ProcessHandle__ = OpenHandle { phdlProcessHandle :: PHANDLE }
                                      , phdlJobHandle     :: PHANDLE
                                      -- ^ the job containing the process and
                                      -- its subprocesses
-                                     , phdlIocpHandle    :: PHANDLE
-                                     -- ^ the job's IO Completion Port
                                      }
                      | ClosedHandle ExitCode
 data ProcessHandle

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -103,7 +103,7 @@ data CreateProcess = CreateProcess{
                                            --
                                            --   @since 1.4.0.0
   use_process_jobs :: Bool                 -- ^ On Windows systems this flag indicates that we should wait for the entire process tree
-                                           --   to finish before unblocking. On POSIX systems this flag is ignored.
+                                           --   to finish before unblocking. On POSIX systems this flag is ignored. See $exec-on-windows for details.
                                            --
                                            --   Default: @False@
                                            --

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -957,7 +957,7 @@ waitForJobCompletion ( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode
         return -1;
     }
 
-    return 0;
+    return 2;
 }
 
 #endif /* Win32 */

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -569,29 +569,6 @@ createJob ()
     return NULL;
 }
 
-static HANDLE
-createCompletionPort (HANDLE hJob)
-{
-    HANDLE ioPort = CreateIoCompletionPort (INVALID_HANDLE_VALUE, NULL, 0, 1);
-    if (!ioPort)
-    {
-        // Something failed. Error is in GetLastError, let caller handler it.
-        return NULL;
-    }
-
-    JOBOBJECT_ASSOCIATE_COMPLETION_PORT Port;
-    Port.CompletionKey = hJob;
-    Port.CompletionPort = ioPort;
-    if (!SetInformationJobObject(hJob,
-        JobObjectAssociateCompletionPortInformation,
-        &Port, sizeof(Port))) {
-        // Something failed. Error is in GetLastError, let caller handler it.
-        return NULL;
-    }
-
-    return ioPort;
-}
-
 /* Note [Windows exec interaction]
 
    The basic issue that process jobs tried to solve is this:
@@ -629,7 +606,7 @@ runInteractiveProcess (wchar_t *cmd, wchar_t *workingDirectory,
                        wchar_t *environment,
                        int fdStdIn, int fdStdOut, int fdStdErr,
                        int *pfdStdInput, int *pfdStdOutput, int *pfdStdError,
-                       int flags, bool useJobObject, HANDLE *hJob, HANDLE *hIOcpPort)
+                       int flags, bool useJobObject, HANDLE *hJob)
 {
     STARTUPINFO sInfo;
     PROCESS_INFORMATION pInfo;
@@ -750,16 +727,8 @@ runInteractiveProcess (wchar_t *cmd, wchar_t *workingDirectory,
         {
             goto cleanup_err;
         }
-
-        // Create the completion port and attach it to the job
-        *hIOcpPort = createCompletionPort(*hJob);
-        if (!*hIOcpPort)
-        {
-            goto cleanup_err;
-        }
     } else {
         *hJob      = NULL;
-        *hIOcpPort = NULL;
     }
 
     if (!CreateProcess(NULL, cmd, NULL, NULL, inherit, dwFlags, environment, workingDirectory, &sInfo, &pInfo))
@@ -803,7 +772,6 @@ cleanup_err:
     if (hStdErrorRead   != INVALID_HANDLE_VALUE) CloseHandle(hStdErrorRead);
     if (hStdErrorWrite  != INVALID_HANDLE_VALUE) CloseHandle(hStdErrorWrite);
     if (useJobObject && hJob      && *hJob     ) CloseHandle(*hJob);
-    if (useJobObject && hIOcpPort && *hIOcpPort) CloseHandle(*hIOcpPort);
 
     maperrno();
     return NULL;
@@ -886,78 +854,49 @@ waitForProcess (ProcHandle handle, int *pret)
     return -1;
 }
 
-
+// Returns true on success.
 int
-waitForJobCompletion ( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode, setterDef set, getterDef get )
+waitForJobCompletion ( HANDLE hJob )
 {
-    DWORD CompletionCode;
-    ULONG_PTR CompletionKey;
-    LPOVERLAPPED Overlapped;
-    *pExitCode = 0;
+    JOBOBJECT_BASIC_PROCESS_ID_LIST pid_list;
+    pid_list.NumberOfAssignedProcesses = 1;
 
-    // We have to loop here. It's a blocking call, but
-    // we get notified on each completion event. So if it's
-    // not one we care for we should just block again.
-    // If all processes are finished before this call is made
-    // then the initial call will return false.
-    // List of events we can listen to:
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684141(v=vs.85).aspx
-    while (GetQueuedCompletionStatus (ioPort, &CompletionCode,
-                                      &CompletionKey, &Overlapped, timeout)) {
+    while (true) {
+      // Find a process in the job...
+      bool success = QueryInformationJobObject(
+          hJob,
+          JobObjectBasicProcessIdList,
+          &pid_list,
+          sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST),
+          NULL);
 
-        // If event wasn't meant of us, keep listening.
-        if ((HANDLE)CompletionKey != hJob)
-          continue;
+      if (pid_list.NumberOfProcessIdsInList == 0) {
+        // We're done
+        return true;
+      }
 
-        switch (CompletionCode)
-        {
-            case JOB_OBJECT_MSG_NEW_PROCESS:
-            {
-                // A new child process is born.
-                // Retrieve and save the process handle from the process id.
-                // We'll need it for later but we can't retrieve it after the
-                // process has exited.
-                DWORD pid    = (DWORD)(uintptr_t)Overlapped;
-                HANDLE pHwnd = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, TRUE, pid);
-                set(pid, pHwnd);
-            }
-            break;
-            case JOB_OBJECT_MSG_ABNORMAL_EXIT_PROCESS:
-            case JOB_OBJECT_MSG_EXIT_PROCESS:
-            {
-                // A child process has just exited.
-                // Read exit code, We assume the last process to exit
-                // is the process whose exit code we're interested in.
-                HANDLE pHwnd = get((DWORD)(uintptr_t)Overlapped);
-                if (GetExitCodeProcess(pHwnd, (DWORD *)pExitCode) == 0)
-                {
-                    maperrno();
-                    return 1;
-                }
-
-                // Check to see if the child has actually exited.
-                if (*(DWORD *)pExitCode == STILL_ACTIVE)
-                  waitForProcess ((ProcHandle)pHwnd, pExitCode);
-            }
-            break;
-            case JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO:
-                // All processes in the tree are done.
-                return 0;
-            default:
-                break;
+      HANDLE pHwnd = OpenProcess(SYNCHRONIZE, TRUE, pid_list.ProcessIdList[0]);
+      if (pHwnd == NULL) {
+        switch (GetLastError()) {
+          case ERROR_INVALID_PARAMETER:
+            // Presumably the process terminated; try again.
+            continue;
+          default:
+            maperrno();
+            return false;
         }
-    }
+      }
 
-    // Check to see if a timeout has occurred or that the
-    // all processes in the job were finished by the time we
-    // got to the loop.
-    if (Overlapped == NULL && (HANDLE)CompletionKey != hJob)
-    {
-        // Timeout occurred.
-        return -1;
-    }
+      // Wait for it to finish...
+      if (WaitForSingleObject(pHwnd, INFINITE) != WAIT_OBJECT_0) {
+        maperrno();
+        CloseHandle(pHwnd);
+        return false;
+      }
 
-    return 2;
+      // The process signalled, loop again to try the next process.
+      CloseHandle(pHwnd);
+    }
 }
 
 #endif /* Win32 */

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+* Fix several bugs on Windows where use of process jobs would result
+  in the process being prematurely terminated. See
+  [#168](https://github.com/haskell/process/168).
+
 ## 1.6.7.0 *November 2019*
 
 * Fix a race condition on Windows that happens when you use process jobs and one of

--- a/include/runProcess.h
+++ b/include/runProcess.h
@@ -86,14 +86,13 @@ extern ProcHandle runInteractiveProcess( wchar_t *cmd,
                                          int *pfdStdError,
                                          int flags,
                                          bool useJobObject,
-                                         HANDLE *hJob,
-                                         HANDLE *hIOcpPort );
+                                         HANDLE *hJob );
 
 typedef void(*setterDef)(DWORD, HANDLE);
 typedef HANDLE(*getterDef)(DWORD);
 
 extern int terminateJob( ProcHandle handle );
-extern int waitForJobCompletion( HANDLE hJob, HANDLE ioPort, DWORD timeout, int *pExitCode, setterDef set, getterDef get );
+extern int waitForJobCompletion( HANDLE hJob );
 
 #endif
 


### PR DESCRIPTION
This fixes the incorrect termination behavior described in #167. The path to get here was a bit meandering.

The "Check exit code of processes using jobs in two stages" commit refactors `waitForProcess` to ensure that the `ProcessHandle`'s `MVar` remains reachable throughout the blocking in `waitForJobCompletion`. It also updates the `MVar` after job completion and closes the OS handles to allow the process's resources to be freed.

However, I then realized that the Win32 documentation [explicitly states](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port) that the delivery of job IOCP notifications is not guaranteed. This is strange and appears to contradict the guidance given by [this blog post](https://devblogs.microsoft.com/oldnewthing/20130405-00/?p=4743) but I have nevertheless observed hung processes that would seem to confirm the lossy behavior.

In light of this, the "Refactor waiting on job objects" commit refactors the job waiting logic to avoid IOCPs entirely. We now rather query the job for a list of its constituent processes, choose one to block on, wait until it has terminated, and iterate until we find that there are no processes left.

Additionally, we give up on trying to choose which process to take the exit code from; the probability that this heuristic works is simply too far from 1 and it otherwise does nothing but contribute non-determinism to the operation.