### PR TITLE
Avoid redundant pattern match warning on Windows

### DIFF
--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -330,10 +330,7 @@ interruptProcessGroupOfInternal ph = do
     withProcessHandle ph $ \p_ -> do
         case p_ of
             ClosedHandle _ -> return ()
-            _ -> do let h = case p_ of
-                              OpenHandle x      -> x
-                              OpenExtHandle x _ -> x
-                              _                 -> error "interruptProcessGroupOfInternal"
+            _ -> do let h = phdlProcessHandle p_
 #if mingw32_HOST_OS
                     pid <- getProcessId h
                     generateConsoleCtrlEvent cTRL_BREAK_EVENT pid

--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -875,6 +875,11 @@ waitForJobCompletion ( HANDLE hJob )
           sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST),
           NULL);
 
+      if (!success) {
+          maperrno();
+          return false;
+      }
+
       if (!success && GetLastError() == ERROR_MORE_DATA) {
         process_count *= 2;
         free(pid_list);


### PR DESCRIPTION
GHC is able to see that the the `ClosedHandle` alternative is unreachable due to the containing `case` analysis.