### PR TITLE
Revert "Check return value of QueryInformationJobObject"

### DIFF
--- a/cbits/runProcess.c
+++ b/cbits/runProcess.c
@@ -875,11 +875,6 @@ waitForJobCompletion ( HANDLE hJob )
           sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST),
           NULL);
 
-      if (!success) {
-          maperrno();
-          return false;
-      }
-
       if (!success && GetLastError() == ERROR_MORE_DATA) {
         process_count *= 2;
         free(pid_list);

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
-## Unreleased changes
+## 1.6.8.2 *March 2020*
+
+* Fix another process wait bug on Windows.
 
 ## 1.6.8.1 *March 2020*
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## Unreleased changes
+
 ## 1.6.8.2 *March 2020*
 
 * Fix another process wait bug on Windows.

--- a/process.cabal
+++ b/process.cabal
@@ -1,5 +1,5 @@
 name:          process
-version:       1.6.8.1
+version:       1.6.8.2
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD3
 license-file:  LICENSE


### PR DESCRIPTION
Unfortunately this change was incorrect and arose from following a misleading compiler warning without carefully checking the logic. Many apologies for the confusion and the bad release that resulted. 

With this reversion Windows finally finishes a GHC validation so I'm reasonably certain that this is release-worthy.

This reverts commit 062a69e2a5b4d5e51c896ee5d0433588b8f4d05c.
