### PR TITLE
Give a usable buffer to _pipe on Windows

### DIFF
--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -308,7 +308,7 @@ createPipeInternal = do
 createPipeInternalFd :: IO (FD, FD)
 createPipeInternalFd = do
     allocaArray 2 $ \ pfds -> do
-        throwErrnoIfMinus1_ "_pipe" $ c__pipe pfds 2 (#const _O_BINARY)
+        throwErrnoIfMinus1_ "_pipe" $ c__pipe pfds 8192 (#const _O_BINARY)
         readfd <- peek pfds
         writefd <- peekElemOff pfds 1
         return (readfd, writefd)


### PR DESCRIPTION
Fixes #181, the documentation seems to have been misread, the argument to `_pipe` is the number of bytes to reserve for pipe communications, not the number of pipes to create.  This ended up making pipes that can only send 2 bytes at a time.

The pipes are created in blocking mode, so any write of larger than 2 bytes block and no read returns more than 2 bytes..

Instead use 8k which is the size of the internal Buffers in `Base` which back `I/O` calls.