### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -77,7 +77,7 @@ library
 
     ghc-options: -Wall
 
-    build-depends: base      >= 4.8.2 && < 4.16,
+    build-depends: base      >= 4.8.2 && < 4.17,
                    directory >= 1.1 && < 1.4,
                    filepath  >= 1.2 && < 1.5,
                    deepseq   >= 1.1 && < 1.5


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462