### PR TITLE
Bump Win32 upper bound to accomodate Win32-2.10

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -57,7 +57,7 @@ library
         c-sources:
             cbits/win32/runProcess.c
         other-modules: System.Process.Windows
-        build-depends: Win32 >=2.2 && < 2.10
+        build-depends: Win32 >=2.2 && < 2.11
         -- ole32 and rpcrt4 are needed to create GUIDs for unique named pipes
         -- for process.
         extra-libraries: kernel32, ole32, rpcrt4


### PR DESCRIPTION
This should be the last change necessary for GHC 9.0. No new release is necessary but a Hackage revision would likely be best.

Thanks again!