### PR TITLE
WIP: make waitForProcess async safe

### DIFF
--- a/cbits/posix/runProcess.c
+++ b/cbits/posix/runProcess.c
@@ -452,30 +452,37 @@ getProcessExitCode (ProcHandle handle, int *pExitCode)
     return -1;
 }
 
-int waitForProcess (ProcHandle handle, int *pret)
+void waitForProcess (ProcHandle handle, int *pret, int *success)
 {
     int wstat;
 
     if (waitpid(handle, &wstat, 0) < 0)
     {
-        return -1;
+        *success = 0;
+        *pret = 0;
+        return;
     }
 
     if (WIFEXITED(wstat)) {
+        *success = 1;
         *pret = WEXITSTATUS(wstat);
-        return 0;
+        return;
     }
     else {
         if (WIFSIGNALED(wstat))
         {
+            *success = 1;
             *pret = TERMSIG_EXITSTATUS(wstat);
-            return 0;
+            return;
         }
         else
         {
+            *success = 0;
+            *pret = 0;
             /* This should never happen */
         }
     }
 
-    return -1;
+    *success = 0;
+    *pret = 0;
 }

--- a/include/runProcess.h
+++ b/include/runProcess.h
@@ -108,4 +108,4 @@ extern int waitForJobCompletion( HANDLE hJob );
 
 extern int terminateProcess( ProcHandle handle );
 extern int getProcessExitCode( ProcHandle handle, int *pExitCode );
-extern int waitForProcess( ProcHandle handle, int *ret );
+extern void waitForProcess( ProcHandle handle, int *ret, int *success );


### PR DESCRIPTION
Moving from https://github.com/fpco/typed-process/issues/38. CC @norfairking

This PR is not complete, the tests fail. I'm trying to determine whether this is a reasonable approach. My understanding of the issue here:

1. `waitForProcess` wants to allow the C FFI call `c_waitForProcess` to be interruptible, so that `waitpid` can be interrupted
2. If an async exception lands at exactly the wrong time, the `waitpid` call with succeed, but the FFI call will throw an exception due to the async exception
3. In this case, the system process table no longer has an entry for the given PID, but the `MVar` inside `ProcessHandle` believes that the handle is still open, allowing future `waitForProcess` calls to occur
4. Future calls throw an exception, since it's using an unknown PID

My best guess is that, in order to both allow `waitpid` to be interrupted _and_ to reliably capture the exit code if it's generated, we need to:

1. No longer rely on return codes from `c_waitForProcess`, since those will be lost in the case of an async exception
2. Therefore, we need to detect whether the `waitpid` call succeeded or not by passing in another `int*` (along with the existing output parameter `pret`).
3. Even if `c_waitForProcess` throws an exception, we need to update the `MVar` with the exit code, if it's returned successfully

I've taken a stab at this in this PR. @simonmar I was hoping you could have a look and let me know if this approach works, and/or if there's a better way to attack this kind of problem.