### PR TITLE
Implement getCurrentPid

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -49,6 +49,7 @@ module System.Process (
     showCommandForUser,
     Pid,
     getPid,
+    getCurrentPid,
 
     -- ** Control-C handling on Unix
     -- $ctlc-handling
@@ -93,8 +94,9 @@ import System.IO
 import System.IO.Error (mkIOError, ioeSetErrorString)
 
 #if defined(WINDOWS)
-import System.Win32.Process (getProcessId, ProcessId)
+import System.Win32.Process (getProcessId, getCurrentProcessId, ProcessId)
 #else
+import System.Posix.Process (getProcessID)
 import System.Posix.Types (CPid (..))
 #endif
 
@@ -256,10 +258,10 @@ withCreateProcess_ fun c action =
                      (\(m_in, m_out, m_err, ph) -> action m_in m_out m_err ph)
 
 -- | Cleans up the process.
--- 
--- This function is meant to be invoked from any application level cleanup 
+--
+-- This function is meant to be invoked from any application level cleanup
 -- handler. It terminates the process, and closes any 'CreatePipe' 'handle's.
--- 
+--
 -- @since 1.6.4.0
 cleanupProcess :: (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
                -> IO ()
@@ -650,6 +652,24 @@ getPid (ProcessHandle mh _ _) = do
     OpenHandle pid -> return $ Just pid
 #endif
     _ -> return Nothing
+
+
+-- ----------------------------------------------------------------------------
+-- getCurrentPid
+
+-- | Returns the PID (process ID) of the current process. On POSIX systems,
+-- this calls 'getProcessID' from "System.Posix.Process" in the @unix@ package.
+-- On Windows, this calls 'getCurrentProcessId' from "System.Win32.Process" in
+-- the @Win32@ package.
+--
+-- @since TODO
+getCurrentPid :: IO Pid
+getCurrentPid =
+#ifdef WINDOWS
+    getCurrentProcessId
+#else
+    getProcessID
+#endif
 
 
 -- ----------------------------------------------------------------------------

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -662,7 +662,7 @@ getPid (ProcessHandle mh _ _) = do
 -- On Windows, this calls 'getCurrentProcessId' from "System.Win32.Process" in
 -- the @Win32@ package.
 --
--- @since TODO
+-- @since 1.6.12.0
 getCurrentPid :: IO Pid
 getCurrentPid =
 #ifdef WINDOWS

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 1.6.12.0 *June 2021*
+
+* Add function `getCurrentPid` to get the currently executing process' ID [#205](https://github.com/haskell/process/pull/205)
+
 ## 1.6.11.0 *January 2021*
 
 * Windows: Add support for new I/O manager in GHC 8.12[#177](https://github.com/haskell/process/pull/177)


### PR DESCRIPTION
### Change

This PR adds a new exported function in System.Process: `getCurrentPid`.

This calls `getCurrentProcessId` from System.Win32.Process on Windows, and `getProcessID` from System.Posix.Process on POSIX systems.

### Rationale

This seems like an oversight considering `getPid` is implemented already. I sometimes require the current running program's process ID. Currently, I have to do the CPP conditional logic myself every time, which is a pain. Putting this in `process` seems natural. 

Furthermore, my understanding of `process` is that it is a unified interface to System.Win32.Process and System.Posix.Process. As both modules provide a function to "get the currently executing process id", I feel it makes sense to have a cross-platform wrapper function.

### Remaining Issues

The `@since` field has been left as a TODO since I'm not sure what version this will be merged in. 

### Tests

I could not come up with a method to test the PR. Unlike with the test for `getPid`, there's nothing to compare the value against, I think. It's worked from my past experiences in personal projects.

I wasn't able to ensure a stable setup to test to begin with, as running the existing test suite `stack test` on the Windows version of Stack failed due to several reasons (`getPid` failing, and `detatch_console` failing). Any feedback or insight is therefore appreciated.