### PR TITLE
Two small fixes

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -8,7 +8,7 @@
 #if !defined(HAVE_POSIX_SPAWNP)
 ProcHandle
 do_spawn_posix (char *const args[],
-                const char *workingDirectory, const char **environment,
+                char *workingDirectory, char **environment,
                 struct std_handle *stdInHdl,
                 struct std_handle *stdOutHdl,
                 struct std_handle *stdErrHdl,

--- a/test/main.hs
+++ b/test/main.hs
@@ -13,12 +13,11 @@ import System.IO (hClose, openBinaryTempFile, hGetContents)
 import qualified Data.ByteString as S
 import qualified Data.ByteString.Char8 as S8
 import System.Directory (getTemporaryDirectory, removeFile)
-import System.Info (os)
 
 ifWindows :: IO () -> IO ()
 ifWindows action
-  | os /= "windows" = return ()
-  | otherwise = action
+  | not isWindows = return ()
+  | otherwise     = action
 
 isWindows :: Bool
 #if WINDOWS


### PR DESCRIPTION
 * Fix const-correctness in non-`posix_spawnp` codepath
 * Consolidate Windows check in testsuite driver.