### PR TITLE
posix_spawn: Don't attempt to dup2 identical fds

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -42,10 +42,15 @@ setup_std_handle_spawn (int fd,
         return 0;
 
     case STD_HANDLE_USE_FD:
-        if (posix_spawn_file_actions_adddup2(fa, hdl->use_fd, fd) != 0) {
-            *failed_doing = "posix_spawn_file_actions_adddup2";
-            return -1;
-        }
+        // N.B. POSIX specifies that dup2(x,x) should be a no-op, but
+        // naturally Apple ignores this and rather fails in posix_spawn on Big
+        // Sur.
+        if (hdl->use_fd != fd) {
+            if (posix_spawn_file_actions_adddup2(fa, hdl->use_fd, fd) != 0) {
+                *failed_doing = "posix_spawn_file_actions_adddup2";
+                return -1;
+            }
+       }
         return 0;
 
     case STD_HANDLE_USE_PIPE:


### PR DESCRIPTION
*Editorial note:* @snoyberg, I'd like to again apologize for how many iterations this `posix_spawn` work has required; it really has been a compatibility nightmare. This particular issue remained under the radar in my Darwin testing on GHC as I had chalked it up to a GHC bug, having seen the same test fail for reasons unrelated to `process`. Sadly, this time the failure is actually due to a bug in Darwin's `posix_spawn_file_actions_adddup2` implementation. Thanks again, for your patience.

macOS Big Sur does not allow the user to `posix_spawn_file_actions_adddup2` an
fd to itself. Instead of behaving as a no-op as specified by POSIX
2017.1 (and as done by every other operating system), it instead fails with
`EBADFD` in `posix_spawn`. This caused a single tricky-to-identify
failure in GHC's testsuite.