### PR TITLE
Fix #216: more documentation of `String` argument of `createProcess_`

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -88,7 +88,7 @@ createProcess_
   :: String
        -- ^ Function name (for error messages).
        --
-       --   This is can be any 'String', but will typically be the name of the caller.
+       --   This can be any 'String', but will typically be the name of the caller.
        --   E.g., 'spawnProcess' passes @"spawnProcess"@ here when calling
        --   'createProcess_'.
   -> CreateProcess


### PR DESCRIPTION
Fix #216: more documentation of `String` argument of `createProcess_`