### PR TITLE
Fix #220: Bump lower bound of Win32 to 2.4

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -58,7 +58,7 @@ library
         c-sources:
             cbits/win32/runProcess.c
         other-modules: System.Process.Windows
-        build-depends: Win32 >=2.2 && < 2.13
+        build-depends: Win32 >=2.4 && < 2.13
         -- ole32 and rpcrt4 are needed to create GUIDs for unique named pipes
         -- for process.
         extra-libraries: kernel32, ole32, rpcrt4


### PR DESCRIPTION
Fix #220: Bump lower bound of Win32 to 2.4

Since v1.6.12.0, process does not build any more with Win32-2.2/3.
I made the necessary revisions on hackage, but the next releases should include this PR.