### PR TITLE
posix: Ensure that errno is set after posix_spawnp fails

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -201,6 +201,7 @@ do_spawn_posix (char *const args[],
 
     r = posix_spawnp(&pid, args[0], &fa, &sa, args, environment ? environment : environ);
     if (r != 0) {
+        errno = r; // posix_spawn doesn't necessarily set errno; see #227.
         *failed_doing = "posix_spawnp";
         goto fail;
     } else {


### PR DESCRIPTION
In contrast to glibc, Darwin's posix_spawnp implementation doesn't set
errno on failure.

Fixes #227.