### PR TITLE
configure: Ensure that posix_spawnp reports ENOENT correctly

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -5,7 +5,7 @@
 #include <errno.h>
 #include <signal.h>
 
-#if !defined(HAVE_POSIX_SPAWNP)
+#if !defined(USE_POSIX_SPAWN)
 ProcHandle
 do_spawn_posix (char *const args[],
                 char *workingDirectory, char **environment,

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,13 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
-## Unreleased
+## 1.6.14.0 *February 2022*
 
 * posix: Ensure that `errno` is set after `posix_spawnp` fails [#228](https://github.com/haskell/process/pull/228)
+* Don't use `posix_spawn` on platforms where it does not report `ENOENT` in caes where the
+  requested executable does not exist [#224](https://github.com/haskell/process/issues/224)
+* Ensure that `find_executable` correctly-locates executables when a change in
+  working directory is requested [#219](https://github.com/haskell/process/issues/219)
+* Fix capitalization error allowing `execvpe` to be used when available.
 
 ## 1.6.13.2 *July 2021*
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,39 @@ AC_CHECK_DECLS([POSIX_SPAWN_SETPGROUP],[],[],[
   #include <spawn.h>
 ])
 
+if test "$ac_cv_func_posix_spawnp" = "yes"; then
+    dnl On OpenBSD posix_spawnp doesn't report ENOENT when
+    dnl the user attempts to spawn a process with a non-existent
+    dnl executable. Don't attempt to use such posix_spawn
+    dnl implementations to ensure errors are reported correctly.
+    dnl See #224.
+
+    AC_MSG_CHECKING(whether posix_spawn reports errors sensibly)
+    AC_RUN_IFELSE(
+        [AC_LANG_PROGRAM([
+             #include <stddef.h>
+             #include <stdbool.h>
+             #include <errno.h>
+             #include <spawn.h>
+           ], [[
+                 pid_t pid;
+                 char *prog = "__nonexistent_program__";
+                 char *args[] = {prog, NULL};
+                 char *env[] = {NULL};
+
+                 // This should fail with ENOENT
+                 int ret = posix_spawnp(&pid, prog, NULL, NULL, args, env);
+                 bool okay = ret == ENOENT;
+                 return !okay;
+           ]]
+         )],
+         [AC_DEFINE([USE_POSIX_SPAWN], [], [posix_spawn should be used])
+          AC_MSG_RESULT(yes)],
+         [AC_MSG_RESULT([no, falling back to fork/exec])]
+    )
+fi
+
+
 FP_CHECK_CONSTS([SIG_DFL SIG_IGN])
 
 AC_OUTPUT

--- a/process.cabal
+++ b/process.cabal
@@ -1,5 +1,5 @@
 name:          process
-version:       1.6.13.2
+version:       1.6.14.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD3
 license-file:  LICENSE


### PR DESCRIPTION
It turns out that POSIX allows implementations to report
errors "lazily" by exiting the spawned process with code 127.

In particular, OpenBSD's implementation returns successfully if the
requested executable doesn't exist. This severely hampers our ability to
report errors accurately.

In this patch we add a `configure` test for sensible error-reporting
from `posix_spawnp` and disable it if the test fails.

Fixes #224.
