### PR TITLE
Phyx/winio permissions and mode fixes

### DIFF
--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -187,7 +187,7 @@ runGenProcess_ fun c _ _ = createProcess_ fun c
 -- When this function is used with WinIO enabled it's the caller's
 -- responsibility to register the handles with the I/O manager.
 -- If this is not done the operation will deadlock.  Association can
--- be done as follow:
+-- be done as follows:
 --
 -- @
 --     #if defined(__IO_MANAGER_WINIO__)

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -182,6 +182,33 @@ runGenProcess_ fun c _ _ = createProcess_ fun c
 -- | Create a pipe for interprocess communication and return a
 -- @(readEnd, writeEnd)@ `Handle` pair.
 --
+-- * WinIO Support
+--
+-- When this function is used with WinIO enabled it's the caller's
+-- responsibility to register the handles with the I/O manager.
+-- If this is not done the operation will deadlock.  Association can
+-- be done as follow:
+--
+-- @
+--     #if defined(__IO_MANAGER_WINIO__)
+--     import GHC.IO.SubSystem ((<!>))
+--     import GHC.IO.Handle.Windows (handleToHANDLE)
+--     import GHC.Event.Windows (associateHandle')
+--     #endif
+--
+--     ...
+--
+--     #if defined (__IO_MANAGER_WINIO__)
+--     return () <|> $ do
+--       associateHandle' =<< handleToHANDLE <handle>
+--     #endif
+-- @
+--
+-- Only associate handles that you are in charge of read/writing to.
+-- Do not associate handles passed to another process.  It's the
+-- process's reponsibility to register the handle if it supports
+-- async access.
+--
 -- @since 1.2.1.0
 createPipe :: IO (Handle, Handle)
 createPipe = createPipeInternal

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -199,8 +199,8 @@ runGenProcess_ fun c _ _ = createProcess_ fun c
 --     ...
 --
 --     #if defined (__IO_MANAGER_WINIO__)
---     return () <|> $ do
---       associateHandle' =<< handleToHANDLE <handle>
+--     return () <!> (do
+--       associateHandle' =<< handleToHANDLE <handle>)
 --     #endif
 -- @
 --

--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -450,8 +450,8 @@ createPipeInternalHANDLE =
    alloca $ \ pfdStdOutput -> do
      throwErrnoIf_  (==False) "c_mkNamedPipe" $
        c_mkNamedPipe pfdStdInput True pfdStdOutput True
-     Just hndStdInput  <- mbPipeHANDLE CreatePipe pfdStdInput WriteMode
-     Just hndStdOutput <- mbPipeHANDLE CreatePipe pfdStdOutput ReadMode
+     Just hndStdInput  <- mbPipeHANDLE CreatePipe pfdStdInput ReadMode
+     Just hndStdOutput <- mbPipeHANDLE CreatePipe pfdStdOutput WriteMode
      return (hndStdInput, hndStdOutput)
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## * unreleased *
+
+* Correct permissions on createPipe on Windows [234](https://github.com/haskell/process/pull/234)
+* Ensure that both ends of pipes on Windows are created in the same mode  [234](https://github.com/haskell/process/pull/234)
+
 ## 1.6.14.0 *February 2022*
 
 * posix: Ensure that `errno` is set after `posix_spawnp` fails [#228](https://github.com/haskell/process/pull/228)


### PR DESCRIPTION
Hi,

This PR fixes several issues:

1. The permissions for the pipes created through `createPipe` were accidentally swapped. The `read` end got `write` permissions while the `write` part got `read` permissions in Haskell.  The permissions were correct in the underlying OS object but this caused a very weird message when the handles were used.  This corrects them so they're in sync.
2.  It documents a requirement for users of `createPipe` in that since we don't know who's going to use which part of the handles that it's the caller's responsibility to associate the handles with the correct I/O manager.   This documents an example on how to do so.
3. Pipes can be opened in two modes, `message` and `byte`, essentially `chunk` and `streaming` mode.   `CreateNamedPipeW` defaults to `message` mode while `CreateFile` defaulted to `byte` mode.  However the modes need to match.  This corrects it by always setting both modes explicitly ensuring that both ends always match.  For these pipes we default to `chunk` instead  of  `streaming` mode as things such as `iserv` require the entire message in order to continue anyway.

This fixes the last issues to enable the new I/O manager with iserv support in GHC.

/cc @bgamari 