### PR TITLE
Support compiling for wasm32-wasi

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -77,6 +77,8 @@ module System.Process (
     rawSystem,
     ) where
 
+#include <ghcplatform.h>
+
 import Prelude hiding (mapM)
 
 import System.Process.Internals
@@ -857,6 +859,19 @@ terminateProcess ph = do
 -- ----------------------------------------------------------------------------
 -- Interface to C bits
 
+#if defined(wasm32_HOST_ARCH)
+
+c_terminateProcess :: PHANDLE -> IO CInt
+c_terminateProcess _ = pure (-1)
+
+c_getProcessExitCode :: PHANDLE -> Ptr CInt -> IO CInt
+c_getProcessExitCode _ _ = pure (-1)
+
+c_waitForProcess :: PHANDLE -> Ptr CInt -> IO CInt
+c_waitForProcess _ _ = pure (-1)
+
+#else
+
 foreign import ccall unsafe "terminateProcess"
   c_terminateProcess
         :: PHANDLE
@@ -874,6 +889,7 @@ foreign import ccall interruptible "waitForProcess" -- NB. safe - can block
         -> Ptr CInt
         -> IO CInt
 
+#endif
 
 -- ----------------------------------------------------------------------------
 -- Old deprecated variants

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -43,6 +43,7 @@ import System.Posix.Process (getProcessGroupIDOf)
 
 import System.Process.Common hiding (mb_delegate_ctlc)
 
+#include <ghcplatform.h>
 #include "HsProcessConfig.h"
 #include "processFlags.h"
 
@@ -262,6 +263,27 @@ endDelegateControlC exitCode = do
       where
         sig = fromIntegral (-n)
 
+#if !defined(HAVE_WORKING_FORK)
+
+c_runInteractiveProcess
+        ::  Ptr CString
+        -> CString
+        -> Ptr CString
+        -> FD
+        -> FD
+        -> FD
+        -> Ptr FD
+        -> Ptr FD
+        -> Ptr FD
+        -> Ptr CGid
+        -> Ptr CUid
+        -> CInt                         -- flags
+        -> Ptr CString
+        -> IO PHANDLE
+c_runInteractiveProcess _ _ _ _ _ _ _ _ _ _ _ _ _ = pure (-1)
+
+#else
+
 foreign import ccall unsafe "runInteractiveProcess"
   c_runInteractiveProcess
         ::  Ptr CString
@@ -278,6 +300,8 @@ foreign import ccall unsafe "runInteractiveProcess"
         -> CInt                         -- flags
         -> Ptr CString
         -> IO PHANDLE
+
+#endif
 
 ignoreSignal, defaultSignal :: CLong
 ignoreSignal  = CONST_SIG_IGN

--- a/cbits/posix/fork_exec.c
+++ b/cbits/posix/fork_exec.c
@@ -3,6 +3,8 @@
 
 #include "common.h"
 
+#if defined(HAVE_WORKING_FORK)
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
@@ -327,3 +329,5 @@ do_spawn_fork (char *const args[],
 
     return pid;
 }
+
+#endif // HAVE_WORKING_FORK

--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -3,8 +3,11 @@
 
 #include <unistd.h>
 #include <errno.h>
+
+#if defined(HAVE_SIGNAL_H)
 #include <signal.h>
 #include <fcntl.h>
+#endif
 
 #if !defined(USE_POSIX_SPAWN)
 ProcHandle

--- a/cbits/posix/runProcess.c
+++ b/cbits/posix/runProcess.c
@@ -7,6 +7,8 @@
 #include "runProcess.h"
 #include "common.h"
 
+#if defined(HAVE_WORKING_FORK)
+
 #include <unistd.h>
 #include <errno.h>
 #include <sys/wait.h>
@@ -265,3 +267,5 @@ waitForProcess (ProcHandle handle, int *pret)
 
     return -1;
 }
+
+#endif // HAVE_WORKING_FORK

--- a/include/runProcess.h
+++ b/include/runProcess.h
@@ -31,7 +31,9 @@ typedef PHANDLE ProcHandle;
 
 #include "processFlags.h"
 
-#if !(defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32))
+#if !defined(HAVE_WORKING_FORK)
+
+#elif !(defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32))
 
 #include <pwd.h>
 #include <grp.h>


### PR DESCRIPTION
This patch postpones compile-time errors to run-time, and allow Haskell projects that link to process but doesn't actually spawn child processes to build on wasm32-wasi successfully.