### PR TITLE
testsuite/process011: Don't rely on Python

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -42,6 +42,8 @@ test('process010', [
     normalise_fun(lambda s: s.replace('illegal operation (Inappropriate ioctl for device)', 'does not exist (No such file or directory)')),
     normalise_exec
 ], compile_and_run, [''])
-test('process011', when(opsys('mingw32'), skip), compile_and_run, [''])
+test('process011',
+     [when(opsys('mingw32'), skip), pre_cmd('{compiler} -no-hs-main -o process011_c process011_c.c')],
+     compile_and_run, [''])
 
 test('T8343', normal, compile_and_run, [''])

--- a/tests/process011.hs
+++ b/tests/process011.hs
@@ -14,24 +14,16 @@ main = do
 
   -- shell kills itself with SIGINT,
   -- delegation off, exit code (death by signal) reported as normal
-  do let script = intercalate " "
-                    [ "exec python3 2>/dev/null"
-                    , "-c"
-                    , "'import os; os.kill(os.getpid(), 2)'"
-                    ]
-     (_,_,_,p) <- createProcess (shell script) { delegate_ctlc = False }
+  do let script = "./process011_c"
+     (_,_,_,p) <- createProcess (proc script []) { delegate_ctlc = False }
      waitForProcess p >>= print
 
   putStrLn "===================== test 2"
 
   -- shell kills itself with SIGINT,
   -- delegation on, so expect to throw UserInterrupt
-  do let script = intercalate " "
-                    [ "exec python3 2>/dev/null"
-                    , "-c"
-                    , "'import os; os.kill(os.getpid(), 2)'"
-                    ]
-     (_,_,_,p) <- createProcess (shell script) { delegate_ctlc = True }
+  do let script = "./process011_c"
+     (_,_,_,p) <- createProcess (proc script []) { delegate_ctlc = True }
      (waitForProcess p >>= print)
        `catchUserInterrupt` \e -> putStrLn $ "caught: " ++ show e
 

--- a/tests/process011_c.c
+++ b/tests/process011_c.c
@@ -1,0 +1,9 @@
+#include <unistd.h>
+#include <signal.h>
+
+int main() {
+        kill(getpid(), SIGINT);
+        sleep(1);
+        return 0;
+}
+


### PR DESCRIPTION
The refactor of `process011` performed in 8cd7e04, where
the test is taught to use `python3` instead of `sh`, has broken the test
on Debian 10. Specifically, for reasons that I don't yet understand,
`python3` exits with code 1 not code 2 when killing itself with
signal 2. Strangely, my tests on other distributions (e.g. NixOS)
suggest that Python's behavior in this case is rather inconsistent.

To avoid this, we now rather use a dedicated C program instead of
Python.

Fixes #241.