### PR TITLE
fix cross-compiling configure issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,9 @@ if test "$ac_cv_func_posix_spawnp" = "yes"; then
          )],
          [AC_DEFINE([USE_POSIX_SPAWN], [], [posix_spawn should be used])
           AC_MSG_RESULT(yes)],
-         [AC_MSG_RESULT([no, falling back to fork/exec])]
+         [AC_MSG_RESULT([no, falling back to fork/exec])],
+         [AC_DEFINE([USE_POSIX_SPAWN], [], [])
+          AC_MSG_RESULT(cross-compiling - assuming yes)]
     )
 fi
 


### PR DESCRIPTION
Hello,
quite recent addition for testing posix_spawn by running actual code broke cross-compiling capability. Simple hack fixes that
by assuming posix_spawn is working fine in this case.
E.g. see #232
