### PR TITLE
winio: Fix Handle mode on inherited handles.

### DIFF
--- a/cbits/win32/runProcess.c
+++ b/cbits/win32/runProcess.c
@@ -142,9 +142,10 @@ mkNamedPipe (HANDLE* pHandleIn, BOOL isInheritableIn,
        bytes and the error ERROR_NO_DATA."[0]
 
        [0] https://devblogs.microsoft.com/oldnewthing/20110114-00/?p=11753  */
+    DWORD inAttr = isInheritableIn ? 0 : FILE_FLAG_OVERLAPPED;
     hTemporaryIn
       = CreateNamedPipeW (pipeName,
-                          PIPE_ACCESS_INBOUND | FILE_FLAG_OVERLAPPED | FILE_FLAG_FIRST_PIPE_INSTANCE,
+                          PIPE_ACCESS_INBOUND | inAttr | FILE_FLAG_FIRST_PIPE_INSTANCE,
                           PIPE_TYPE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS | PIPE_READMODE_MESSAGE | PIPE_WAIT,
                           1, buffer_size, buffer_size,
                           0,
@@ -161,7 +162,9 @@ mkNamedPipe (HANDLE* pHandleIn, BOOL isInheritableIn,
                      FILE_SHARE_WRITE,
                      &secAttr,
                      OPEN_EXISTING,
-                     FILE_FLAG_OVERLAPPED,
+                     isInheritableOut
+                       ? FILE_ATTRIBUTE_NORMAL
+                       : FILE_FLAG_OVERLAPPED,
                      NULL);
 
     if (hTemporaryOut == INVALID_HANDLE_VALUE)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Correct permissions on createPipe on Windows [234](https://github.com/haskell/process/pull/234)
 * Ensure that both ends of pipes on Windows are created in the same mode  [234](https://github.com/haskell/process/pull/234)
+* Fixed an issue with WINIO where giving an application an inherited pipe can cause it to misbehave [245](https://github.com/haskell/process/pull/245)
 
 ## 1.6.14.0 *February 2022*
 


### PR DESCRIPTION
There's a small bug in the modes that we create handles with when we make inheritable handles.

We create both the input and output handles with `FILE_FLAG_OVERLAPPED`.
This is OK as long as the program being called is also not using IOCP. For the majority of the program
usually called this is the case and so we never noticed the bug in testing.

However when calling an application which is also using overlapped IO *or* uses the kernel low level
async APIs then the spawned application will misbehave because the operation would unexpectedly
become asynchronous.  This is the case with any program using Microsoft VC++'s stdlibs to read pipes.

The fix is to only mark handles with `FILE_FLAG_OVERLAPPED` if they are *not* being inherited.  That is,
only make them asynchronous if we, the caller will be using them and not the callee.

Note that WINIO can handle synchronous handles as well, so even if some other part of the program
uses the synchronous handle it would still work correctly.

Fixes https://gitlab.haskell.org/ghc/ghc/-/issues/21610

/cc @bgamari 