### PR TITLE
winio: match mio in setting default encoding for pipes instead

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -292,6 +292,7 @@ mbPipeHANDLE CreatePipe pfd  mode =
   do raw_handle <- peek pfd
      let hwnd  = fromHANDLE raw_handle :: Io NativeHandle
          ident = "hwnd:" ++ show raw_handle
-     Just <$> mkHandleFromHANDLE hwnd Stream ident mode Nothing
+     enc <- fmap Just getLocaleEncoding
+     Just <$> mkHandleFromHANDLE hwnd Stream ident mode enc
 mbPipeHANDLE _std      _pfd _mode = return Nothing
 #endif

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Correct permissions on createPipe on Windows [234](https://github.com/haskell/process/pull/234)
 * Ensure that both ends of pipes on Windows are created in the same mode  [234](https://github.com/haskell/process/pull/234)
 * Fixed an issue with WINIO where giving an application an inherited pipe can cause it to misbehave [245](https://github.com/haskell/process/pull/245)
+* Set the encoding on WINIO created pipes to the local encoding as with MIO [248](https://github.com/haskell/process/pull/248)
 
 ## 1.6.14.0 *February 2022*
 


### PR DESCRIPTION
This sets the default locale to be the current locale to match what the previous I/O manager was doing.

For WINIO the locale doesn't matter as all data is binary and we re-encode internally, however the locale seems to unexpectedly influence the line break detection in GHC.

As such we set the locale so it uses `\r\n` instead of `\n`.