### PR TITLE
Use POSIX_SPAWN_CLOEXEC_DEFAULT in posix_spawn.c when available

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -96,9 +96,15 @@ do_spawn_posix (char *const args[],
     if (childGroup || childUser) {
         return -2;
     }
+
+    short spawn_flags = 0;
+
     if ((flags & RUN_PROCESS_IN_CLOSE_FDS) != 0) {
-        // TODO: can this be efficiently supported?
+#if defined(HAVE_POSIX_SPAWN_CLOEXEC_DEFAULT)
+        spawn_flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
+#else
         return -2;
+#endif
     }
 
     // Now the main act...
@@ -107,7 +113,6 @@ do_spawn_posix (char *const args[],
     posix_spawnattr_t sa;
     int r;
     ProcHandle ret;
-    short spawn_flags = 0;
 
     r = posix_spawn_file_actions_init(&fa);
     if (r != 0) {

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,10 @@ AC_CHECK_DECLS([POSIX_SPAWN_SETSID, POSIX_SPAWN_SETSID_NP],[],[],[
   #define _GNU_SOURCE
   #include <spawn.h>
 ])
+AC_CHECK_DECLS([POSIX_SPAWN_CLOEXEC_DEFAULT],[],[],[
+  #define _GNU_SOURCE
+  #include <spawn.h>
+])
 AC_CHECK_DECLS([POSIX_SPAWN_SETPGROUP],[],[],[
   #define _GNU_SOURCE
   #include <spawn.h>


### PR DESCRIPTION
I'm looking at improving performance when `close_fds=True` after encountering #189.

I noticed this could be improved on MacOS where this flag is available. Making the `do_spawn_posix` function handle more situations will result in fewer fallbacks to the (possibly less performant) `do_spawn_fork`.

I haven't tested this yet, hoping to see how it works on CI.