### PR TITLE
Fix process#251

### DIFF
--- a/tests/all.T
+++ b/tests/all.T
@@ -47,3 +47,4 @@ test('process011',
      compile_and_run, [''])
 
 test('T8343', normal, compile_and_run, [''])
+test('processT251', normal, compile_and_run, [''])

--- a/tests/processT251.hs
+++ b/tests/processT251.hs
@@ -1,0 +1,36 @@
+import Control.Exception
+import GHC.IO.Exception
+import System.Environment
+import System.Exit
+import System.Process
+
+main :: IO ()
+main = do
+    args <- getArgs
+    case args of
+      []         -> parent
+      ["child"]  -> child
+      ["child2"] -> child2
+      _          -> fail "unknown mode"
+
+parent :: IO ()
+parent = do
+    putStrLn "parent start"
+    (_, _, _, phdl) <- createProcess $ (proc "./processT251" ["child"]) { std_in = NoStream }
+    ExitSuccess <- waitForProcess phdl
+    putStrLn "parent done"
+
+child :: IO ()
+child = do
+    putStrLn "child start"
+    (_, _, _, phdl) <- createProcess $ (proc "./processT251" ["child2"]) { std_in = NoStream }
+    ExitSuccess <- waitForProcess phdl
+    putStrLn "child done"
+
+child2 :: IO ()
+child2 = do
+    putStrLn "child2 start"
+    Left (IOError {ioe_type=InvalidArgument}) <-
+        try $ getContents >>= print
+    putStrLn "child2 done"
+

--- a/tests/processT251.stdout
+++ b/tests/processT251.stdout
@@ -1,0 +1,6 @@
+child2 start
+child2 done
+child start
+child done
+parent start
+parent done


### PR DESCRIPTION
Previously to spawn a process with a closed standard handle, we
would use `posix_spawn_file_action_addclose`. However, it turns out that
POSIX specifies that `spawnp()` may fail if `addclose()` is used on an
fd that is already closed. While glibc and musl appear to ignore this
aspect of the specification, Darwin indeed follows it leading to #251.

This behavior is rather unfortunate as
`posix_spawn_file_action_addclose` is a convenient way to close a handle
in a subprocess in a race-free manner (e.g. unlike `O_CLOEXEC`, which is
global). To avoid #251 we must first use
`posix_spawn_file_action_addopen` on the fd (e.g. opening `/dev/null`)
to be closed to ensure that it is valid, which has the side-effect of
closing the inherited fd. We can then safely use
`posix_spawn_file_action_addclose` to close the fd.

Fixes #251.
