### PR TITLE
testsuite: Don't attempt to read from inherited fd in processT251

### DIFF
--- a/tests/processT251.hs
+++ b/tests/processT251.hs
@@ -30,7 +30,10 @@ child = do
 child2 :: IO ()
 child2 = do
     putStrLn "child2 start"
-    Left (IOError {ioe_type=InvalidArgument}) <-
-        try $ getContents >>= print
+    -- Unfortunate, there isn't a reliable way to test that stdin has been closed.
+    -- Afterall, if any file is opened in the child, it may reuse the
+    -- supposedly-closed fd 0. In particular this tends to happen in the
+    -- threaded RTS, since the event manager's control pipe is opened during
+    -- RTS initialzation.
     putStrLn "child2 done"
 


### PR DESCRIPTION
It turns out that the test for `processT251` is subtly broken. In particular, the test will fail if any file is opened in the subprocess before the child is run since the closed fd 0 may be reused for the new file. This tends to happen in the threaded RTS due to the event manager's control pipe (see GHC #22395). Unfortunately, it's not really clear how else this can be reliably tested.

Given that this only touches the GHC bit of the testsuite which isn't usable via `cabal-install` or stack, I don't think an immediate release is strictly necessary here.