### PR TITLE
Bump bounds to accomodate base-4.18

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -81,7 +81,7 @@ library
 
     ghc-options: -Wall
 
-    build-depends: base      >= 4.10 && < 4.18,
+    build-depends: base      >= 4.10 && < 4.19,
                    directory >= 1.1 && < 1.4,
                    filepath  >= 1.2 && < 1.5,
                    deepseq   >= 1.1 && < 1.5


### PR DESCRIPTION
In service of GHC 9.6.1.