### PR TITLE
Fix a non-existent macro unset by GHC

### DIFF
--- a/System/Process.hs
+++ b/System/Process.hs
@@ -6,6 +6,8 @@
 #endif
 {-# LANGUAGE InterruptibleFFI #-}
 
+#include <ghcplatform.h>
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Process
@@ -102,7 +104,7 @@ import System.Posix.Types (CPid (..))
 
 import GHC.IO.Exception ( ioException, IOErrorType(..), IOException(..) )
 
-#if defined(__wasm__)
+#if defined(wasm32_HOST_ARCH)
 import GHC.IO.Exception ( unsupportedOperation )
 import System.IO.Error
 #endif
@@ -862,7 +864,7 @@ terminateProcess ph = do
 -- ----------------------------------------------------------------------------
 -- Interface to C bits
 
-#if defined(__wasm__)
+#if defined(wasm32_HOST_ARCH)
 
 c_terminateProcess :: PHANDLE -> IO CInt
 c_terminateProcess _ = ioError (ioeSetLocation unsupportedOperation "terminateProcess")

--- a/System/Process/Posix.hs
+++ b/System/Process/Posix.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+
+#include <ghcplatform.h>
+
 module System.Process.Posix
     ( mkProcessHandle
     , translateInternal
@@ -43,7 +46,7 @@ import System.Posix.Process (getProcessGroupIDOf)
 
 import System.Process.Common hiding (mb_delegate_ctlc)
 
-#if defined(__wasm__)
+#if defined(wasm32_HOST_ARCH)
 import System.IO.Error
 #endif
 
@@ -266,7 +269,7 @@ endDelegateControlC exitCode = do
       where
         sig = fromIntegral (-n)
 
-#if defined(__wasm__)
+#if defined(wasm32_HOST_ARCH)
 
 c_runInteractiveProcess
         ::  Ptr CString

--- a/include/runProcess.h
+++ b/include/runProcess.h
@@ -31,7 +31,9 @@ typedef PHANDLE ProcHandle;
 
 #include "processFlags.h"
 
-#if defined(__wasm__)
+#include <ghcplatform.h>
+
+#if defined(wasm32_HOST_ARCH)
 
 #elif !(defined(_MSC_VER) || defined(__MINGW32__) || defined(_WIN32))
 


### PR DESCRIPTION
This PR corrects an unfortunate mistake in #270. The `__wasm__` macro is a builtin system macro defined by `clang` when targetting `wasm32`, however, the autoconf scripts in GHC will automatically add `-undef` to the CPP flags that GHC uses to invoke `clang`, therefore this flag is unset and will result in a link-time error for `wasm32-wasi-ghc`.

After this fix lands, the existing test for cross GHC will also be updated to ensure these `process` functions are included as a part of the test to avoid any regression here.