### PR TITLE
Fix build on Solaris

### DIFF
--- a/cbits/posix/fork_exec.c
+++ b/cbits/posix/fork_exec.c
@@ -1,6 +1,11 @@
 /* ensure that execvpe is provided if possible */
 #define _GNU_SOURCE 1
 
+/* Ensure getpwuid_r(3) is available on Solaris. */
+#if defined(__sun)
+#define _POSIX_PTHREAD_SEMANTICS
+#endif
+
 #include "common.h"
 
 #if defined(HAVE_FORK)


### PR DESCRIPTION
On Solaris, getpwuid_r(3) is only available when _POSIX_PTHREAD_SEMANTICS is defined.