### PR TITLE
Windows: don't wait indefinitely on processes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
             then
               # Looks like a bug in Stack, this shouldn't break things
               ls C:/ProgramData/Chocolatey/bin/
-              rm C:/ProgramData/Chocolatey/bin/ghc*
+              rm -rf C:/ProgramData/Chocolatey/bin/ghc*
               stack ${{ matrix.args }} exec pacman -- --sync --refresh --noconfirm autoconf
             fi
             stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## unreleased
+
+* Fix deadlock when waiting for process completion and process jobs [#273](https://github.com/haskell/process/issues/273)
+
 ## 1.6.17.0 *February 2023*
 
 * Improved documentation for the `OpenExtHandle` constructor.


### PR DESCRIPTION
The Windows kernel will release a process only when the last handle to it is closed.

This means that the call to `WaitForSingleObject` does not return until every other process closes any handles they may have opened to the program, including pipes passed to it.

However if on the Haskell side we haven't released the handle yet then we deadlock and wait indefinitely.  There is a race condition in that if when we get to `WaitForSingleObject` the kernel has already cleaned up the process then we'll return immediately, which is what is happening with the first test in the test program.

The old workflow for this wait function used to be that we iterate until the process list is empty.  On each we wait indefinitely.

The new workflow is different in that instead of waiting indefinitely we wait for 200ms and re-test the application.  Essentially we poll the first process that doesn't return `STILL_ACTIVE`.   It's less efficient than before but it's the only way to avoid the race condition.

Fixes #273 
Fixes https://github.com/haskell/cabal/issues/8688
Fixes https://github.com/haskell/cabal/issues/8208

Waiting for GHC bootstrap and testsuite to finish https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10080?diff_id=193677

/CC @bgamari @snoyberg 