### PR TITLE
Windows: Implement delegate_ctlc on Windows

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -92,8 +92,6 @@ data CreateProcess = CreateProcess{
   create_group :: Bool,                    -- ^ Create a new process group
   delegate_ctlc:: Bool,                    -- ^ Delegate control-C handling. Use this for interactive console processes to let them handle control-C themselves (see below for details).
                                            --
-                                           --   On Windows this has no effect.
-                                           --
                                            --   @since 1.2.0.0
   detach_console :: Bool,                  -- ^ Use the windows DETACHED_PROCESS flag when creating the process; does nothing on other platforms.
                                            --

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -171,7 +171,6 @@ runGenProcess_
  -> Maybe CLong                -- ^ handler for SIGINT
  -> Maybe CLong                -- ^ handler for SIGQUIT
  -> IO (Maybe Handle, Maybe Handle, Maybe Handle, ProcessHandle)
--- On Windows, setting delegate_ctlc has no impact
 runGenProcess_ fun c (Just sig) (Just sig') | isDefaultSignal sig && sig == sig'
                          = createProcess_ fun c { delegate_ctlc = True }
 runGenProcess_ fun c _ _ = createProcess_ fun c

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Fix deadlock when waiting for process completion and process jobs [#273](https://github.com/haskell/process/issues/273)
+* Support delegate_ctlc on Windows. [#278](https://github.com/haskell/process/pull/278)
 
 ## 1.6.17.0 *February 2023*
 


### PR DESCRIPTION
This implements `delegate_ctlc` on Windows so the calling process can properly ignore SIGINT.

Without this cabal repl doesn't behave correctly.

validated working with manual tests and cabal.

to address https://github.com/haskell/cabal/issues/8820