### PR TITLE
Drop vfork support

### DIFF
--- a/cbits/posix/fork_exec.c
+++ b/cbits/posix/fork_exec.c
@@ -29,15 +29,9 @@
 #include <signal.h>
 #endif
 
-#if defined(HAVE_VFORK_H)
-#include <vfork.h>
-#endif
-
 #include <Rts.h>
 
-#if defined(HAVE_WORKING_VFORK)
-#define myfork vfork
-#elif defined(HAVE_WORKING_FORK)
+#if defined(HAVE_WORKING_FORK)
 #define myfork fork
 // We don't need a fork command on Windows
 #else
@@ -152,7 +146,7 @@ do_spawn_fork (char *const args[],
     }
 #endif
 
-    int pid = myfork();
+    int pid = fork();
     switch(pid)
     {
     case -1:
@@ -164,10 +158,6 @@ do_spawn_fork (char *const args[],
         return -1;
 
     case 0:
-        // WARNING! We may now be in the child of vfork(), and any
-        // memory we modify below may also be seen in the parent
-        // process.
-
         close(forkCommunicationFds[0]);
         fcntl(forkCommunicationFds[1], F_SETFD, FD_CLOEXEC);
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 ## unreleased
 
 * Fix deadlock when waiting for process completion and process jobs [#273](https://github.com/haskell/process/issues/273)
-* Support delegate_ctlc on Windows. [#278](https://github.com/haskell/process/pull/278)
+* Support `delegate_ctlc` on Windows. [#278](https://github.com/haskell/process/pull/278)
+* Drop support for `vfork` [#261](https://github.com/haskell/process/pull/261)
 
 ## 1.6.17.0 *February 2023*
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_HEADERS([include/HsProcessConfig.h])
 
 AC_PROG_CC
 
-dnl ** Working vfork?
+dnl ** Working fork?
 AC_FUNC_FORK
 
 # check for specific header (.h) files that we are interested in


### PR DESCRIPTION
`vfork` is something of a relic, originally introduced as a (rather unsafe) optimisation of `fork` in 3.0BSD, allowing the user to eliminate the cost of cloning the parent process's address space (as early BSDs would do) when `fork`ing with the intent of immediately `exec`ing.

However, its design has long been considered a mistake (being nigh impossible to use safely in a multithreaded environment), its benefits have largely vanished (since modern operating systems rely on virtual memory to remap the parent's address space as copy-on-write instead of copying), and nearly all platforms now consider it to be an alias of `fork`.

Remove `process`'s support for `vfork`.

Fixes #261.