### PR TITLE
cbits: Ensure that fork pipe doesn't shadow std fds

### DIFF
--- a/cbits/posix/fork_exec.c
+++ b/cbits/posix/fork_exec.c
@@ -102,6 +102,32 @@ setup_std_handle_fork(int fd,
     }
 }
 
+/* We must ensure that the fork communications pipe does not inhabit fds 0
+ * through 2 since we will need to manipulate these fds in
+ * setup_std_handle_fork while keeping the pipe available so that it can report
+ * errors. See #266.
+ */
+int unshadow_pipe_fd(int fd, char **failed_doing) {
+    if (fd <= 2) {
+        int fd2 = dup(fd);
+        if (fd2 == -1) {
+            *failed_doing = "dup(unshadow)";
+            return -1;
+        }
+
+        // This should recurse at most three times
+        int fd3 = unshadow_pipe_fd(fd2, failed_doing);
+        if (close(fd2) == -1) {
+            *failed_doing = "close(unshadow)";
+            return -1;
+        }
+
+        return fd3;
+    } else {
+        return fd;
+    }
+}
+
 /* Try spawning with fork. */
 ProcHandle
 do_spawn_fork (char *const args[],
@@ -117,6 +143,16 @@ do_spawn_fork (char *const args[],
     int r = pipe(forkCommunicationFds);
     if (r == -1) {
         *failed_doing = "pipe";
+        return -1;
+    }
+
+    // Ensure that the pipe fds don't shadow stdin/stdout/stderr
+    forkCommunicationFds[0] = unshadow_pipe_fd(forkCommunicationFds[0], failed_doing);
+    if (forkCommunicationFds[0] == -1) {
+        return -1;
+    }
+    forkCommunicationFds[1] = unshadow_pipe_fd(forkCommunicationFds[1], failed_doing);
+    if (forkCommunicationFds[1] == -1) {
         return -1;
     }
 


### PR DESCRIPTION
Previously we would assume that the pipe used to communicate errors from the child back to the parent did not shadow the standard descriptors (stdin, stdout, and stderr). Somewhat surprisingly, this appears to hold most platforms. However, OpenBSD appears to be a notable exception.

Avoid relying on this assumption by `dup`ing the pipe fds until they end up out of the standard fd range.

Closes #266.