### PR TITLE
testsuite: mark tests as req_process

### DIFF
--- a/tests/T9775/all.T
+++ b/tests/T9775/all.T
@@ -3,12 +3,14 @@ test('T9775_fail',
      [extra_clean(['ok.o', 'ok.exe', 'main.o', 'main.exe']),
       extra_files(['ok.c', 'main.c']),
       unless(opsys('mingw32'),skip),
-      pre_cmd('$MAKE -s --no-print-directory T9775')],
+      pre_cmd('$MAKE -s --no-print-directory T9775'),
+      req_process],
       compile_and_run, [''])
 
 test('T9775_good',
      [extra_clean(['ok.o', 'ok.exe', 'main.o', 'main.exe']),
       unless(opsys('mingw32'),skip),
       extra_files(['ok.c', 'main.c']),
-      pre_cmd('$MAKE -s --no-print-directory T9775')],
+      pre_cmd('$MAKE -s --no-print-directory T9775'),
+      req_process],
       compile_and_run, [''])

--- a/tests/all.T
+++ b/tests/all.T
@@ -2,52 +2,57 @@
 # in spurious error output changes.
 normalise_exec = normalise_fun(lambda s: s.replace('posix_spawnp', 'exec'))
 
-test('process001', [extra_clean(['process001.out']), js_broken(22349)], compile_and_run, [''])
-test('process002', [fragile_for(16547, concurrent_ways), extra_clean(['process002.out']), js_broken(22349)], compile_and_run, [''])
-test('process003', [fragile_for(17245, concurrent_ways), omit_ways(['ghci']), js_broken(22349)], compile_and_run, [''])
-test('process004', [normalise_exec, normalise_exe, js_broken(22349)], compile_and_run, [''])
-test('T1780', js_broken(22349), compile_and_run, [''])
-test('process005', [omit_ways(['ghci']), js_broken(22349)], compile_and_run, [''])
-test('process006', js_broken(22349), compile_and_run, [''])
+test('process001', [extra_clean(['process001.out']), js_broken(22349), req_process], compile_and_run, [''])
+test('process002', [fragile_for(16547, concurrent_ways), extra_clean(['process002.out']), js_broken(22349), req_process], compile_and_run, [''])
+test('process003', [fragile_for(17245, concurrent_ways), omit_ways(['ghci']), js_broken(22349), req_process], compile_and_run, [''])
+test('process004', [normalise_exec, normalise_exe, js_broken(22349), req_process], compile_and_run, [''])
+test('T1780', [js_broken(22349), req_process], compile_and_run, [''])
+test('process005', [omit_ways(['ghci']), js_broken(22349), req_process], compile_and_run, [''])
+test('process006', [js_broken(22349), req_process], compile_and_run, [''])
 
 test('process007',
      [extra_clean(['process007.tmp',
                    'process007_fd.o', 'process007_fd', 'process007_fd.exe']),
       when(opsys('mingw32'), skip),
       pre_cmd('$MAKE -s --no-print-directory process007_fd'),
-      js_broken(22349)],
+      js_broken(22349),
+      req_process],
      compile_and_run, [''])
-test('process008', js_broken(22349), compile_and_run, [''])
+test('process008', [js_broken(22349), req_process], compile_and_run, [''])
 
 # not the normal way: this test runs processes from multiple threads, and
 # will get stuck without the threaded RTS.
 test('T3231',
      [only_ways(['threaded1','threaded2']),
-      extra_clean(['foo1.txt', 'foo2.txt'])],
+      extra_clean(['foo1.txt', 'foo2.txt']),
+      req_process],
      compile_and_run,
      [''])
 test('T4198',
      [pre_cmd('{compiler} exitminus1.c -no-hs-main -o exitminus1'),
       extra_clean(['exitminus1.o', 'exitminus1', 'exitminus1.exe']),
-      js_broken(22349)],
+      js_broken(22349),
+      req_process],
      compile_and_run,
      [''])
 
 test('T3994', [only_ways(['threaded1','threaded2']),
                extra_files(['T3994app.hs']),
-               pre_cmd('$MAKE -s --no-print-directory T3994app')],
+               pre_cmd('$MAKE -s --no-print-directory T3994app'),
+               req_process],
      compile_and_run, [''])
-test('T4889',js_broken(22349), compile_and_run, [''])
+test('T4889',[js_broken(22349), req_process], compile_and_run, [''])
 
-test('process009', [when(opsys('mingw32'), skip), js_broken(22349)], compile_and_run, [''])
+test('process009', [when(opsys('mingw32'), skip), js_broken(22349), req_process], compile_and_run, [''])
 test('process010', [
     normalise_fun(lambda s: s.replace('illegal operation (Inappropriate ioctl for device)', 'does not exist (No such file or directory)')),
     normalise_exec,
-    js_broken(22349)
+    js_broken(22349),
+    req_process
 ], compile_and_run, [''])
 test('process011',
-     [when(opsys('mingw32'), skip), pre_cmd('{compiler} -no-hs-main -o process011_c process011_c.c'), js_broken(22349)],
+     [when(opsys('mingw32'), skip), pre_cmd('{compiler} -no-hs-main -o process011_c process011_c.c'), js_broken(22349), req_process],
      compile_and_run, [''])
 
-test('T8343', js_broken(22349), compile_and_run, [''])
-test('processT251', js_broken(22349), compile_and_run, [''])
+test('T8343', [js_broken(22349), req_process], compile_and_run, [''])
+test('processT251', [js_broken(22349), req_process], compile_and_run, [''])


### PR DESCRIPTION
This patch marks `process` tests as `req_process`  as implemented in https://gitlab.haskell.org/ghc/ghc/-/merge_requests/10224, and is intended to be included in that MR as a part of work to run the entire GHC testsuite for the wasm backend. This predicate asserts that the target platform indeed has a process model, and skips the tests in case there isn't (e.g. `wasm32-wasi`).