### PR TITLE
Revert "Use POSIX_SPAWN_CLOEXEC_DEFAULT in posix_spawn.c when available"

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -108,15 +108,9 @@ do_spawn_posix (char *const args[],
     if (childGroup || childUser) {
         return -2;
     }
-
-    short spawn_flags = 0;
-
     if ((flags & RUN_PROCESS_IN_CLOSE_FDS) != 0) {
-#if defined(HAVE_POSIX_SPAWN_CLOEXEC_DEFAULT)
-        spawn_flags |= POSIX_SPAWN_CLOEXEC_DEFAULT;
-#else
+        // TODO: can this be efficiently supported?
         return -2;
-#endif
     }
 
     // Now the main act...
@@ -125,6 +119,7 @@ do_spawn_posix (char *const args[],
     posix_spawnattr_t sa;
     int r;
     ProcHandle ret;
+    short spawn_flags = 0;
 
     r = posix_spawn_file_actions_init(&fa);
     if (r != 0) {

--- a/configure.ac
+++ b/configure.ac
@@ -31,10 +31,6 @@ AC_CHECK_DECLS([POSIX_SPAWN_SETSID, POSIX_SPAWN_SETSID_NP],[],[],[
   #define _GNU_SOURCE
   #include <spawn.h>
 ])
-AC_CHECK_DECLS([POSIX_SPAWN_CLOEXEC_DEFAULT],[],[],[
-  #define _GNU_SOURCE
-  #include <spawn.h>
-])
 AC_CHECK_DECLS([POSIX_SPAWN_SETPGROUP],[],[],[
   #define _GNU_SOURCE
   #include <spawn.h>


### PR DESCRIPTION
This reverts commit f47c8699eff0e2bfa37e5a096d905d9b88a558d6. This was incorrectly merged. See #254.