### PR TITLE
posix_spawn: Add support for posix_spawn_file_actions_addchdir_np

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -136,11 +136,17 @@ do_spawn_posix (char *const args[],
 
     if (workingDirectory) {
 #if defined(HAVE_posix_spawn_file_actions_addchdir)
-        // N.B. this function is broken on macOS.
-        // See https://github.com/rust-lang/rust/pull/80537.
         r = posix_spawn_file_actions_addchdir(&fa, workingDirectory);
         if (r != 0) {
             *failed_doing = "posix_spawn_file_actions_addchdir";
+            goto fail;
+        }
+#elif defined(HAVE_posix_spawn_file_actions_addchdir_np)
+        // N.B. this function is broken on macOS.
+        // See https://github.com/rust-lang/rust/pull/80537.
+        r = posix_spawn_file_actions_addchdir_np(&fa, workingDirectory);
+        if (r != 0) {
+            *failed_doing = "posix_spawn_file_actions_addchdir_np";
             goto fail;
         }
 #else

--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -135,7 +135,7 @@ do_spawn_posix (char *const args[],
     }
 
     if (workingDirectory) {
-#if defined(HAVE_posix_spawn_file_actions_addchdir_np)
+#if defined(HAVE_posix_spawn_file_actions_addchdir)
         // N.B. this function is broken on macOS.
         // See https://github.com/rust-lang/rust/pull/80537.
         r = posix_spawn_file_actions_addchdir(&fa, workingDirectory);

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_CHECK_FUNCS([pipe2],[],[],[
 
 # posix_spawn checks
 AC_CHECK_HEADERS([spawn.h])
-AC_CHECK_FUNCS([posix_spawnp posix_spawn_file_actions_addchdir],[],[],[
+AC_CHECK_FUNCS([posix_spawnp posix_spawn_file_actions_addchdir_np posix_spawn_file_actions_addchdir],[],[],[
   #define _GNU_SOURCE
   #include <spawn.h>
 ])


### PR DESCRIPTION
It appears that glibc still has not introduced support for `posix_spawn_file_actions_addchdir`, despite it being ratified by Austin Group. Add support for `posix_spawn_file_actions_addchdir_np` as a stop-gap solution since the removal of the `vfork` path has turned up some pathological cases in the `fork` path in user code.

Also fix a typo which rendered the previous `posix_spawn_file_actions_addchdir_np` path unusable.