### PR TITLE
fork-exec: Don't double-close parent fds

### DIFF
--- a/cbits/posix/fork_exec.c
+++ b/cbits/posix/fork_exec.c
@@ -335,16 +335,8 @@ do_spawn_fork (char *const args[],
         // our responsibility to reap here as nobody else can.
         waitpid(pid, NULL, 0);
 
-        // Already closed child ends above
-        if (stdInHdl->behavior == STD_HANDLE_USE_PIPE) {
-            close(stdInHdl->use_pipe.parent_end);
-        }
-        if (stdOutHdl->behavior == STD_HANDLE_USE_PIPE) {
-            close(stdOutHdl->use_pipe.parent_end);
-        }
-        if (stdErrHdl->behavior == STD_HANDLE_USE_PIPE) {
-            close(stdErrHdl->use_pipe.parent_end);
-        }
+        // No need to close stdin, et al. here as runInteractiveProcess will
+        // handle this. See #306.
 
         pid = -1;
     }


### PR DESCRIPTION
Previously the fork/exec backend would attempt to close stdin, et al. on process spawn failure. This result in spurious `close` failures due to `runInteractiveProcess` doing the same. Consequently, the cause of the failure would be confusingly mis-identified.

Fixes #306.