### PR TITLE
Draft: CommunicationHandle (WinIO): re-open handle in child process with overlap flag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,47 +3,114 @@ name: Tests
 on:
     pull_request:
     push:
-        branches:
-        - master
+      branches:
+        - '**'
 
 jobs:
   build:
-    name: CI
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        args:
-        - "--resolver ghc-9.8.1"
-        - "--resolver ghc-9.6.3"
-        - "--resolver ghc-9.4.7"
-        - "--resolver ghc-9.2.8"
-        - "--resolver ghc-9.0.1"
-        - "--resolver ghc-8.10.4"
-        - "--resolver ghc-8.8.4"
-        - "--resolver ghc-8.6.5"
-        - "--resolver ghc-8.4.4"
-        - "--resolver ghc-8.2.2"
+        ghc-version:
+          - 'latest'
+          - '9.8'
+          - '9.6'
+          - '9.4'
+          - '9.2'
+          - '9.0'
+          - '8.10'
+          - '8.8'
+          - '8.6'
+          - '8.4'
+          - '8.2'
+
+        exclude:
+          # Exclude GHC 8.2 on Windows (GHC bug: undefined reference to `__stdio_common_vswprintf_s')
+          - os: windows-latest
+            ghc-version: '8.2'
 
     steps:
-      - name: Clone project
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Build and run tests
-        shell: bash
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Set up autotools (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            autotools
+
+      - name: Run autoreconf (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: autoreconf -i
+        shell: "msys2 {0}"
+
+      - name: Run autoreconf (Linux & Mac)
+        if: ${{ runner.os != 'Windows' }}
+        run: autoreconf -i
+
+      - name: Configure the build
         run: |
-            set -ex
-            stack upgrade
-            stack --version
-            if [[ "${{ runner.os }}" = 'Windows' ]]
-            then
-              # Looks like a bug in Stack, this shouldn't break things
-              ls C:/ProgramData/Chocolatey/bin/
-              rm -rf C:/ProgramData/Chocolatey/bin/ghc*
-              stack ${{ matrix.args }} exec pacman -- --sync --refresh --noconfirm autoconf
-            fi
-            stack build
-            stack sdist --test-tarball
-            cd test
-            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build process --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: cabal build process
+
+      - name: Run tests
+        run: cabal run process-tests:test
+
+        # On Windows and with GHC >= 9.0, re-run the test-suite using WinIO.
+      - name: Re-run tests with WinIO (Windows && GHC >= 9.0)
+        if: ${{ runner.os == 'Windows' && matrix.ghc-version >= '9.0' }}
+        run: cabal run process-tests:test -- +RTS --io-manager=native -RTS
+
+      - name: Source dist
+        run: cabal sdist all --ignore-project
+
+      - name: Build documentation
+        run: cabal haddock process
+
+      - name: Check process.cabal
+        run: cabal check
+
+      - name: Check process-tests.cabal
+        working-directory: ./test
+        run: cabal check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,7 @@ jobs:
               rm -rf C:/ProgramData/Chocolatey/bin/ghc*
               stack ${{ matrix.args }} exec pacman -- --sync --refresh --noconfirm autoconf
             fi
-            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}
+            stack build
             stack sdist --test-tarball
+            cd test
+            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-/.cabal-sandbox/
-/cabal.project.local
-/cabal.sandbox.config
-/dist/
-/dist-newstyle/
-/.stack-work/
+**/.cabal-sandbox/
+**/cabal.project.local
+**/cabal.sandbox.config
+**/dist/
+**/dist-newstyle/
+**/.stack-work/
 *.swp
+stack.yaml.lock
 
 # Specific generated files
 GNUmakefile

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,5 +1,6 @@
 module Main (main) where
 
+-- Cabal
 import Distribution.Simple
   ( defaultMainWithHooks
   , autoconfUserHooks

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,11 @@
 module Main (main) where
 
 import Distribution.Simple
+  ( defaultMainWithHooks
+  , autoconfUserHooks
+  )
+
+--------------------------------------------------------------------------------
 
 main :: IO ()
 main = defaultMainWithHooks autoconfUserHooks

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -105,13 +105,12 @@ import System.IO.Error (mkIOError, ioeSetErrorString)
 
 #if defined(javascript_HOST_ARCH)
 import System.Process.JavaScript(getProcessId, getCurrentProcessId)
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 import System.Win32.Process (getProcessId, getCurrentProcessId, ProcessId)
 #else
 import System.Posix.Process (getProcessID)
 import System.Posix.Types (CPid (..))
 #endif
-
 import GHC.IO.Exception ( ioException, IOErrorType(..), IOException(..) )
 
 #if defined(wasm32_HOST_ARCH)
@@ -126,7 +125,7 @@ import System.IO.Error
 -- @since 1.6.3.0
 #if defined(javascript_HOST_ARCH)
 type Pid = Int
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 type Pid = ProcessId
 #else
 type Pid = CPid
@@ -667,7 +666,7 @@ getPid (ProcessHandle mh _ _) = do
     OpenHandle h -> do
       pid <- getProcessId h
       return $ Just pid
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
     OpenHandle h -> do
       pid <- getProcessId h
       return $ Just pid
@@ -690,7 +689,7 @@ getCurrentPid :: IO Pid
 getCurrentPid =
 #if defined(javascript_HOST_ARCH)
     getCurrentProcessId
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
     getCurrentProcessId
 #else
     getProcessID
@@ -742,7 +741,7 @@ waitForProcess ph@(ProcessHandle _ delegating_ctlc _) = lockWaitpid $ do
         when (was_open && delegating_ctlc) $
           endDelegateControlC e
         return e'
-#if defined(WINDOWS)
+#if defined(mingw32_HOST_OS)
     OpenExtHandle h job -> do
         -- First wait for completion of the job...
         waitForJobCompletion job
@@ -871,7 +870,7 @@ terminateProcess ph = do
   withProcessHandle ph $ \p_ ->
     case p_ of
       ClosedHandle  _ -> return ()
-#if defined(WINDOWS)
+#if defined(mingw32_HOST_OS)
       OpenExtHandle{} -> terminateJobUnsafe p_ 1 >> return ()
 #else
       OpenExtHandle{} -> error "terminateProcess with OpenExtHandle should not happen on POSIX."

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -21,7 +21,7 @@ module System.Process.Common
     , pfdToHandle
 
 -- Avoid a warning on Windows
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     , CGid (..)
 #else
     , CGid
@@ -63,7 +63,7 @@ import GHC.JS.Prim (JSVal)
 
 -- We do a minimal amount of CPP here to provide uniform data types across
 -- Windows and POSIX.
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
 import Data.Word (Word32)
 import System.Win32.DebugApi (PHANDLE)
 #if defined(__IO_MANAGER_WINIO__)
@@ -75,7 +75,7 @@ import System.Posix.Types
 
 #if defined(javascript_HOST_ARCH)
 type PHANDLE = JSVal
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 -- Define some missing types for Windows compatibility. Note that these values
 -- will never actually be used, as the setuid/setgid system calls are not
 -- applicable on Windows. No value of this type will ever exist.

--- a/System/Process/CommunicationHandle.hsc
+++ b/System/Process/CommunicationHandle.hsc
@@ -1,0 +1,371 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE RankNTypes #-}
+
+module System.Process.CommunicationHandle
+  ( -- * 'CommunicationHandle': a 'Handle' that can be serialised,
+    -- enabling inter-process communication.
+    CommunicationHandle
+      -- NB: opaque, as the representation depends on the operating system
+  , openCommunicationHandleRead
+  , openCommunicationHandleWrite
+  , closeCommunicationHandle
+    -- * Creating 'CommunicationHandle's to communicate with
+    -- a child process
+  , createWeReadTheyWritePipe
+  , createTheyReadWeWritePipe
+   -- * High-level API
+  , readCreateProcessWithExitCodeCommunicationHandle
+  )
+ where
+
+import Control.Arrow ( first )
+import Foreign.C (CInt(..), throwErrnoIf_)
+import GHC.IO.Handle (Handle())
+#if defined(mingw32_HOST_OS)
+import Foreign.Marshal (alloca)
+import Foreign.Ptr (Ptr, ptrToWordPtr, wordPtrToPtr)
+import Foreign.Storable (Storable(peek))
+import GHC.IO.Handle.FD (fdToHandle)
+import GHC.IO.IOMode (IOMode(ReadMode, WriteMode))
+##  if defined(__IO_MANAGER_WINIO__)
+import Control.Exception (catch, throwIO)
+import GHC.IO (onException)
+import GHC.IO.Device as IODevice (close, devType)
+import GHC.IO.Encoding (getLocaleEncoding)
+import GHC.IO.Exception (IOException(..), IOErrorType(InvalidArgument))
+import GHC.IO.IOMode (IOMode(ReadWriteMode))
+import GHC.IO.Handle.Windows (mkHandleFromHANDLE)
+import GHC.IO.SubSystem ((<!>))
+import GHC.IO.Windows.Handle (Io, NativeHandle, fromHANDLE)
+import GHC.Event.Windows (associateHandle')
+import GHC.Windows (HANDLE)
+import System.Process.Common (rawHANDLEToHandle)
+##  else
+import System.Process.Common (rawFdToHandle)
+##  endif
+
+#include <fcntl.h>     /* for _O_BINARY */
+
+#else
+import System.Posix
+  ( Fd(..), fdToHandle
+  , FdOption(..), setFdOption
+  )
+import GHC.IO.FD (FD(fdFD))
+-- NB: we use GHC.IO.Handle.Fd.handleToFd rather than System.Posix.handleToFd,
+-- as the latter flushes and closes the `Handle`, which is not the behaviour we want.
+import GHC.IO.Handle.FD (handleToFd)
+#endif
+
+import System.Process.Internals
+  ( CreateProcess(..), ignoreSigPipe, withForkWait,
+##if !defined(mingw32_HOST_OS)
+  createPipe
+##endif
+  )
+import System.Process
+  ( withCreateProcess, waitForProcess )
+
+import GHC.IO (evaluate)
+import GHC.IO.Handle (hClose)
+import System.Exit (ExitCode)
+
+import Control.DeepSeq (NFData, rnf)
+
+--------------------------------------------------------------------------------
+-- Communication handles.
+
+-- | A 'CommunicationHandle' is an operating-system specific representation
+-- of a 'Handle' that can be communicated through a command-line interface.
+--
+-- In a typical use case, the parent process creates a pipe, using e.g.
+-- 'createWeReadTheyWritePipe' or 'createTheyReadWeWritePipe'.
+--
+--  - One end of the pipe is a 'Handle', which can be read from/written to by
+--    the parent process.
+--  - The other end is a 'CommunicationHandle', which can be inherited by a
+--    child process. A reference to the handle can be serialised (using
+--    the 'Show' instance), and passed to the child process.
+--    It is recommended to close the parent's reference to the 'CommunicationHandle'
+--    using 'closeCommunicationHandle' after it has been inherited by the child
+--    process.
+--  - The child process can deserialise the 'CommunicationHandle' (using
+--    the 'Read' instance), and then use 'useCommunicationHandle'
+--    in order to retrieve a 'Handle' which it can write to/read from.
+--
+-- 'readCreateProcessWithExitCodeCommunicationHandle' provides a high-level API
+-- to this functionality. See there for example code.
+--
+-- @since 1.6.19.0
+newtype CommunicationHandle =
+  CommunicationHandle
+##if defined(mingw32_HOST_OS)
+    HANDLE
+##else
+    Fd
+##endif
+  deriving ( Eq, Ord )
+
+#if defined(mingw32_HOST_OS)
+type Fd = CInt
+##  if !defined(__IO_MANAGER_WINIO__)
+type HANDLE = Ptr ()
+##  endif
+#endif
+
+-- @since 1.6.19.0
+instance Show CommunicationHandle where
+  showsPrec p (CommunicationHandle h) =
+    showsPrec p
+##if defined(mingw32_HOST_OS)
+      $ ptrToWordPtr
+##endif
+      h
+
+-- @since 1.6.19.0
+instance Read CommunicationHandle where
+  readsPrec p str =
+    fmap
+      ( first $ CommunicationHandle
+##if defined(mingw32_HOST_OS)
+              . wordPtrToPtr
+##endif
+      ) $
+      readsPrec p str
+
+-- | Turn the 'CommunicationHandle' into a 'Handle' that can be read from
+-- in the current process.
+--
+-- @since 1.6.19.0
+openCommunicationHandleRead :: CommunicationHandle -> IO Handle
+openCommunicationHandleRead = useCommunicationHandle True
+
+-- | Turn the 'CommunicationHandle' into a 'Handle' that can be written to
+-- in the current process.
+--
+-- @since 1.6.19.0
+openCommunicationHandleWrite :: CommunicationHandle -> IO Handle
+openCommunicationHandleWrite = useCommunicationHandle False
+
+-- | Internal function used to define 'openCommunicationHandleRead' and
+-- openCommunicationHandleWrite.
+useCommunicationHandle :: Bool -> CommunicationHandle -> IO Handle
+useCommunicationHandle wantToRead (CommunicationHandle ch) = do
+##if defined(__IO_MANAGER_WINIO__)
+  return ()
+    <!> associateHandleWithFallback wantToRead ch
+##endif
+  getGhcHandle ch
+
+##if defined(__IO_MANAGER_WINIO__)
+-- Internal function used when associating a 'HANDLE' with the current process.
+--
+-- Explanation: with WinIO, a synchronous handle cannot be associated with the
+-- current process, while an asynchronous one must be associated before being usable.
+--
+-- In a child process, we don't necessarily know which kind of handle we will receive,
+-- so we try to associate it (in case it is an asynchronous handle). This might
+-- fail (if the handle is synchronous), in which case we continue in synchronous
+-- mode (without associating).
+--
+-- With the current API, inheritable handles in WinIO created with mkNamedPipe
+-- are synchronous, but it's best to be safe in case the child receives an
+-- asynchronous handle anyway.
+associateHandleWithFallback :: Bool -> HANDLE -> IO ()
+associateHandleWithFallback _wantToRead h =
+  associateHandle' h `catch` handler
+  where
+    handler :: IOError -> IO ()
+    handler ioErr@(IOError { ioe_handle = _mbErrHandle, ioe_type = errTy, ioe_errno = mbErrNo })
+      -- Catches the following error that occurs when attemping to associate
+      -- a HANDLE that does not have OVERLAPPING mode set:
+      --
+      --   associateHandleWithIOCP: invalid argument (The parameter is incorrect.)
+      | InvalidArgument <- errTy
+      , Just 22 <- mbErrNo
+      = return ()
+      | otherwise
+      = throwIO ioErr
+##endif
+
+-- | Close a 'CommunicationHandle'.
+--
+-- Use this to close the 'CommunicationHandle' in the parent process after
+-- the 'CommunicationHandle' has been inherited by the child process.
+--
+-- @since 1.6.19.0
+closeCommunicationHandle :: CommunicationHandle -> IO ()
+closeCommunicationHandle (CommunicationHandle ch) =
+  hClose =<< getGhcHandle ch
+
+-- | Gets a GHC Handle File description from the given OS Handle or POSIX fd.
+
+#if defined(mingw32_HOST_OS)
+getGhcHandle :: HANDLE -> IO Handle
+getGhcHandle =
+  getGhcHandlePOSIX
+##  if defined(__IO_MANAGER_WINIO__)
+    <!> getGhcHandleNative
+##  endif
+
+getGhcHandlePOSIX :: HANDLE -> IO Handle
+getGhcHandlePOSIX handle = openHANDLE handle >>= fdToHandle
+
+openHANDLE :: HANDLE -> IO Fd
+openHANDLE handle = _open_osfhandle handle (#const _O_BINARY)
+
+foreign import ccall "io.h _open_osfhandle"
+  _open_osfhandle :: HANDLE -> CInt -> IO Fd
+
+##  if defined(__IO_MANAGER_WINIO__)
+getGhcHandleNative :: HANDLE -> IO Handle
+getGhcHandleNative hwnd =
+  do mb_codec <- fmap Just getLocaleEncoding
+     let iomode = ReadWriteMode
+         native_handle = fromHANDLE hwnd :: Io NativeHandle
+     hw_type <- IODevice.devType $ native_handle
+     mkHandleFromHANDLE native_handle hw_type (show hwnd) iomode mb_codec
+       `onException` IODevice.close native_handle
+##  endif
+#else
+getGhcHandle :: Fd -> IO Handle
+getGhcHandle fd = fdToHandle fd
+#endif
+
+--------------------------------------------------------------------------------
+-- Creating pipes.
+
+-- | Create a pipe @(weRead,theyWrite)@ that the current process can read from,
+-- and whose write end can be passed to a child process in order to receive data from it.
+--
+-- See 'CommunicationHandle'.
+--
+-- @since 1.6.19.0
+createWeReadTheyWritePipe :: IO (Handle, CommunicationHandle)
+createWeReadTheyWritePipe = createCommunicationPipe id
+
+-- | Create a pipe @(theyRead,weWrite)@ that the current process can write to,
+-- and whose read end can be passed to a child process in order to send data to it.
+--
+-- See 'CommunicationHandle'.
+--
+-- @since 1.6.19.0
+createTheyReadWeWritePipe :: IO (CommunicationHandle, Handle)
+createTheyReadWeWritePipe = sw <$> createCommunicationPipe sw
+  where
+    sw (a,b) = (b,a)
+
+-- | Internal helper function used to define 'createWeReadTheyWritePipe'
+-- and 'createTheyReadWeWritePipe' while reducing code duplication.
+createCommunicationPipe
+  :: ( forall a. (a, a) -> (a, a) )
+  -> IO (Handle, CommunicationHandle)
+createCommunicationPipe mbSwap = do
+##if !defined(mingw32_HOST_OS)
+  (ourHandle, theirHandle) <- mbSwap <$> createPipe
+  -- Don't allow the child process to inherit a parent file descriptor
+  -- (such inheritance happens by default on Unix).
+  ourFD   <- Fd . fdFD <$> handleToFd ourHandle
+  setFdOption ourFD CloseOnExec True
+  theirFD <- Fd . fdFD <$> handleToFd theirHandle
+  return (ourHandle, CommunicationHandle theirFD)
+##else
+  trueForWinIO <-
+    return False
+##  if defined (__IO_MANAGER_WINIO__)
+      <!> return True
+##  endif
+  -- On Windows, use mkNamedPipe to create the two pipe ends.
+  alloca $ \ pfdStdInput  ->
+    alloca $ \ pfdStdOutput -> do
+      let (inheritRead, inheritWrite) = mbSwap (False, True)
+          -- If we're using WinIO, make the parent pipe end overlapped,
+          -- otherwise make both pipe ends synchronous.
+          overlappedRead  = if inheritRead  then False else trueForWinIO
+          overlappedWrite = if inheritWrite then False else trueForWinIO
+      throwErrnoIf_ (==False) "c_mkNamedPipe" $
+        -- Create one end to be un-inheritable and the other
+        -- to be inheritable, which ensures the parent end can be properly
+        -- associated with the parent process.
+        c_mkNamedPipe
+          pfdStdInput  inheritRead  overlappedRead
+          pfdStdOutput inheritWrite overlappedWrite
+      let ((ourPtr, ourMode), (theirPtr, _theirMode)) =
+            mbSwap ((pfdStdInput, ReadMode), (pfdStdOutput, WriteMode))
+      ourHANDLE  <- peek ourPtr
+      theirHANDLE <- peek theirPtr
+      -- With WinIO, we need to associate any handles we are going to use in
+      -- the current process before being able to use them.
+      return ()
+##  if defined (__IO_MANAGER_WINIO__)
+        <!> associateHandle' ourHANDLE
+##  endif
+      ourHandle <-
+##  if !defined (__IO_MANAGER_WINIO__)
+        rawFdToHandle ourMode =<< openHANDLE ourHANDLE
+##  else
+        -- NB: it's OK to call the following function even when we're not
+        -- using WinIO at runtime, so we don't use <!>.
+        rawHANDLEToHandle ourMode ourHANDLE
+##  endif
+      return $ (ourHandle, CommunicationHandle theirHANDLE)
+
+foreign import ccall "mkNamedPipe" c_mkNamedPipe ::
+    Ptr HANDLE -> Bool -> Bool -> Ptr HANDLE -> Bool -> Bool -> IO Bool
+
+##endif
+
+--------------------------------------------------------------------------------
+
+-- | A version of 'readCreateProcessWithExitCode' that communicates with the
+-- child process through a pair of 'CommunicationHandle's.
+--
+-- Example usage:
+--
+-- > readCreateProcessWithExitCodeCommunicationHandle
+-- >   (\(chTheyRead, chTheyWrite) -> proc "child-exe" [show chTheyRead, show chTheyWrite])
+-- >   (\ hWeRead -> hGetContents hWeRead)
+-- >   (\ hWeWrite -> hPut hWeWrite "xyz")
+--
+-- where @child-exe@ is a separate executable that is implemented as:
+--
+-- > main = do
+-- >   [chRead, chWrite] <- getArgs
+-- >   hRead  <- useCommunicationHandle $ read chRead
+-- >   hWrite <- useCommunicationHandle $ read chWrite
+-- >   input <- hGetContents hRead
+-- >   hPut hWrite $ someFn input
+-- >   hClose hWrite
+--
+-- @since 1.6.19.0
+readCreateProcessWithExitCodeCommunicationHandle
+  :: NFData a
+  => ((CommunicationHandle, CommunicationHandle) -> CreateProcess)
+    -- ^ Process to spawn, given a @(read, write)@ pair of
+    -- 'CommunicationHandle's that are inherited by the spawned process
+  -> (Handle -> IO a)
+    -- ^ read action
+  -> (Handle -> IO ())
+    -- ^ write action
+  -> IO (ExitCode, a)
+readCreateProcessWithExitCodeCommunicationHandle mkProg readAction writeAction = do
+  (chTheyRead, hWeWrite   ) <- createTheyReadWeWritePipe
+  (hWeRead   , chTheyWrite) <- createWeReadTheyWritePipe
+  let cp = mkProg (chTheyRead, chTheyWrite)
+  -- The following implementation parallels 'readCreateProcess'
+  withCreateProcess cp $ \ _ _ _ ph -> do
+    -- Close the parent's references to the 'CommunicationHandle's after they
+    -- have been inherited by the child (we don't want to keep pipe ends open).
+    closeCommunicationHandle chTheyWrite
+    closeCommunicationHandle chTheyRead
+
+    -- Fork off a thread that waits on the output.
+    output <- readAction hWeRead
+    withForkWait (evaluate $ rnf output) $ \ waitOut -> do
+      ignoreSigPipe $ writeAction hWeWrite
+      ignoreSigPipe $ hClose hWeWrite
+      waitOut
+      hClose hWeRead
+
+    ex <- waitForProcess ph
+    return (ex, output)

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -22,7 +22,7 @@
 module System.Process.Internals (
     ProcessHandle(..), ProcessHandle__(..),
     PHANDLE, closePHANDLE, mkProcessHandle,
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     CGid(..),
 #else
     CGid,
@@ -39,7 +39,7 @@ module System.Process.Internals (
     endDelegateControlC,
     stopDelegateControlC,
     unwrapHandles,
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     terminateJob,
     terminateJobUnsafe,
     waitForJobCompletion,
@@ -68,7 +68,7 @@ import System.Process.Common
 
 #if defined(javascript_HOST_ARCH)
 import System.Process.JavaScript
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 import System.Process.Windows
 #else
 import System.Process.Posix

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -56,11 +56,17 @@ module System.Process.Internals (
     createPipe,
     createPipeFd,
     interruptProcessGroupOf,
+    withForkWait,
+    ignoreSigPipe,
     ) where
 
+import Control.Concurrent
+import Control.Exception (SomeException, mask, try, throwIO)
+import qualified Control.Exception as C
 import Foreign.C
 import System.IO
 
+import GHC.IO.Exception ( IOErrorType(..), IOException(..) )
 import GHC.IO.Handle.FD (fdToHandle)
 import System.Posix.Internals (FD)
 
@@ -243,3 +249,29 @@ interruptProcessGroupOf
     :: ProcessHandle    -- ^ A process in the process group
     -> IO ()
 interruptProcessGroupOf = interruptProcessGroupOfInternal
+
+-- | Fork a thread while doing something else, but kill it if there's an
+-- exception.
+--
+-- This is important in the cases above because we want to kill the thread
+-- that is holding the Handle lock, because when we clean up the process we
+-- try to close that handle, which could otherwise deadlock.
+--
+-- @since 1.6.19.0
+withForkWait :: IO () -> (IO () ->  IO a) -> IO a
+withForkWait async body = do
+  waitVar <- newEmptyMVar :: IO (MVar (Either SomeException ()))
+  mask $ \restore -> do
+    tid <- forkIO $ try (restore async) >>= putMVar waitVar
+    let wait = takeMVar waitVar >>= either throwIO return
+    restore (body wait) `C.onException` killThread tid
+
+-- | Handle any SIGPIPE errors in the given computation.
+--
+-- @since 1.6.19.0
+ignoreSigPipe :: IO () -> IO ()
+ignoreSigPipe = C.handle $ \e -> case e of
+                                   IOError { ioe_type  = ResourceVanished
+                                           , ioe_errno = Just ioe }
+                                     | Errno ioe == ePIPE -> return ()
+                                   _ -> throwIO e

--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -515,14 +515,14 @@ createPipeInternalHANDLE =
   alloca $ \ pfdStdInput  ->
    alloca $ \ pfdStdOutput -> do
      throwErrnoIf_  (==False) "c_mkNamedPipe" $
-       c_mkNamedPipe pfdStdInput True pfdStdOutput True
+       c_mkNamedPipe pfdStdInput True False pfdStdOutput True False
      Just hndStdInput  <- mbPipeHANDLE CreatePipe pfdStdInput ReadMode
      Just hndStdOutput <- mbPipeHANDLE CreatePipe pfdStdOutput WriteMode
      return (hndStdInput, hndStdOutput)
 
 
 foreign import ccall "mkNamedPipe" c_mkNamedPipe ::
-    Ptr HANDLE -> Bool -> Ptr HANDLE -> Bool -> IO Bool
+    Ptr HANDLE -> Bool -> Bool -> Ptr HANDLE -> Bool -> Bool -> IO Bool
 ##endif
 
 close' :: CInt -> IO ()

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ., test

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## 1.6.19.0 *April 2024*
+
+* Introduce `System.Process.CommunicationHandle`, allowing for platform-independent
+  inter-process communication using `Handle`s.
+* Expose `withForkWait` and `ignoreSigPipe` from `System.Process.Internals`.
+* Define new internal functions `rawFdToHandle` and (Windows only) `rawHANDLEToHandle`,
+  exported from `System.Process.Common`.
+
 ## 1.6.18.0 *September 2023*
 
 * Fix deadlock when waiting for process completion and process jobs [#273](https://github.com/haskell/process/issues/273)

--- a/process.cabal
+++ b/process.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process
-version:       1.6.18.0
+version:       1.6.19.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD-3-Clause
 license-file:  LICENSE
@@ -54,6 +54,7 @@ library
     exposed-modules:
         System.Cmd
         System.Process
+        System.Process.CommunicationHandle
         System.Process.Internals
     other-modules: System.Process.Common
     if os(windows)

--- a/process.cabal
+++ b/process.cabal
@@ -1,14 +1,14 @@
+cabal-version: 2.4
 name:          process
 version:       1.6.18.0
 -- NOTE: Don't forget to update ./changelog.md
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
 bug-reports:   https://github.com/haskell/process/issues
 synopsis:      Process libraries
 category:      System
 build-type:    Configure
-cabal-version: >=1.10
 description:
     This package contains libraries for dealing with system processes.
     .
@@ -18,9 +18,11 @@ description:
     read more about it at
     <https://github.com/fpco/typed-process/#readme>.
 
+extra-doc-files:
+    changelog.md
+
 extra-source-files:
     aclocal.m4
-    changelog.md
     configure
     configure.ac
     include/HsProcessConfig.h.in
@@ -90,19 +92,3 @@ library
                    directory >= 1.1 && < 1.4,
                    filepath  >= 1.2 && < 1.6,
                    deepseq   >= 1.1 && < 1.6
-
-test-suite test
-  default-language: Haskell2010
-  hs-source-dirs: test
-  main-is: main.hs
-  type: exitcode-stdio-1.0
-  -- Add otherwise redundant bounds on base since GHC's build system runs
-  -- `cabal check`, which mandates bounds on base.
-  build-depends: base >= 4 && < 5
-               , bytestring
-               , directory
-               , process
-  ghc-options: -threaded
-               -with-rtsopts "-N"
-  if os(windows)
-        cpp-options: -DWINDOWS

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,12 @@
 resolver: ghc-9.2.3
+
+packages:
+  - .
+  - test
+
+extra-deps:
+  - Cabal-3.6.3.0
+
+allow-newer: True
+allow-newer-deps:
+  - Cabal

--- a/test/LICENSE
+++ b/test/LICENSE
@@ -1,0 +1,31 @@
+Copyright (c) 2024, the Haskell process developers.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Isaac Jones nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/Setup.hs
+++ b/test/Setup.hs
@@ -1,0 +1,79 @@
+{-# OPTIONS_GHC -Wall #-}
+
+module Main (main) where
+
+-- Cabal
+import Distribution.Simple
+  ( defaultMainWithHooks
+  , simpleUserHooks
+  , UserHooks(buildHook)
+  )
+import Distribution.Simple.BuildPaths
+  ( autogenComponentModulesDir
+  , exeExtension
+  )
+import Distribution.Simple.LocalBuildInfo
+  ( hostPlatform
+  , buildDir
+  , withTestLBI
+  )
+import Distribution.Types.LocalBuildInfo
+  ( LocalBuildInfo
+  , allTargetsInBuildOrder'
+  )
+import Distribution.Types.Component
+  ( Component(CExe) )
+import Distribution.Types.Executable
+  ( Executable(exeName) )
+import Distribution.Types.PackageDescription
+  ( PackageDescription )
+import Distribution.Types.TargetInfo
+  ( targetComponent )
+import Distribution.Types.UnqualComponentName
+  ( unUnqualComponentName )
+
+-- directory
+import System.Directory
+  ( createDirectoryIfMissing )
+
+-- filepath
+import System.FilePath
+  ( (</>), (<.>), takeDirectory )
+
+--------------------------------------------------------------------------------
+
+main :: IO ()
+main = defaultMainWithHooks testProcessHooks
+
+-- The following code works around Cabal bug #9854.
+--
+-- The process-tests package has an executable component named "cli-child",
+-- used for testing. We want to invoke this executable when running tests;
+-- however, due to the Cabal bug this executable does not get added to PATH.
+-- To fix this, we create a "Test.Paths" module in a Custom setup script,
+-- which contains paths to executables used for testing.
+testProcessHooks :: UserHooks
+testProcessHooks =
+  simpleUserHooks
+    { buildHook = \ pd lbi userHooks buildFlags ->
+        withTestLBI pd lbi $ \ _testSuite clbi -> do
+          let pathsFile = autogenComponentModulesDir lbi clbi </> "Test" </> "Paths" <.> "hs"
+          createDirectoryIfMissing True (takeDirectory pathsFile)
+          writeFile pathsFile $ unlines
+            [ "module Test.Paths where"
+            , "processInternalExes :: [(String, FilePath)]"
+            , "processInternalExes = " ++ show (processInternalExes pd lbi)
+            ]
+          buildHook simpleUserHooks pd lbi userHooks buildFlags
+    }
+
+processInternalExes :: PackageDescription -> LocalBuildInfo -> [(String, FilePath)]
+processInternalExes pd lbi =
+  [ (toolName, toolLocation)
+  | tgt <- allTargetsInBuildOrder' pd lbi
+  , CExe exe <- [targetComponent tgt]
+  , let toolName = unUnqualComponentName $ exeName exe
+        toolLocation =
+          buildDir lbi
+            </> (toolName </> toolName <.> exeExtension (hostPlatform lbi))
+  ]

--- a/test/cli-child/main.hs
+++ b/test/cli-child/main.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE BangPatterns #-}
+module Main ( main ) where
+
+-- base
+import System.Environment
+import System.IO
+
+-- deepseq
+import Control.DeepSeq
+  ( force )
+
+-- process
+import System.Process.CommunicationHandle
+  ( openCommunicationHandleRead
+  , openCommunicationHandleWrite
+  )
+
+#if defined(__IO_MANAGER_WINIO__)
+import GHC.IO.SubSystem ((<!>))
+#endif
+
+--------------------------------------------------------------------------------
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [ chRead, chWrite ] -> do
+      childUsesWinIO <-
+        return False
+#if defined(__IO_MANAGER_WINIO__)
+          <!> return True
+#endif
+      putStr $ unlines
+        [ "cli-child {"
+        , " childUsesWinIO: " ++ show childUsesWinIO ]
+      hRead  <- openCommunicationHandleRead  $ read chRead
+      hWrite <- openCommunicationHandleWrite $ read chWrite
+      input <- hGetContents hRead
+      let !output = force $ reverse input ++ "123"
+      hPutStr hWrite output
+      putStrLn "cli-child }"
+      hClose hWrite
+    _ -> error $
+      unlines [ "expected two CommunicationHandle arguments, but got:"
+              , show args ]

--- a/test/main.hs
+++ b/test/main.hs
@@ -22,7 +22,7 @@ ifWindows action
   | otherwise     = action
 
 isWindows :: Bool
-#if WINDOWS
+#if defined(mingw32_HOST_OS)
 isWindows = True
 #else
 isWindows = False

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,0 +1,32 @@
+cabal-version: 2.4
+name:          process-tests
+version:       1.6.18.0
+license:       BSD-3-Clause
+license-file:  LICENSE
+maintainer:    libraries@haskell.org
+bug-reports:   https://github.com/haskell/process/issues
+synopsis:      Testing package for the process library
+category:      System
+build-type:    Simple
+description:
+    This package contains the testing infrastructure for the process library
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/process.git
+  subdir:   test
+
+test-suite test
+  default-language: Haskell2010
+  hs-source-dirs: .
+  main-is: main.hs
+  type: exitcode-stdio-1.0
+  -- Add otherwise redundant bounds on base since GHC's build system runs
+  -- `cabal check`, which mandates bounds on base.
+  build-depends: base >= 4 && < 5
+               , bytestring
+               , deepseq
+               , directory
+               , filepath
+               , process == 1.6.18.0
+  ghc-options: -threaded -rtsopts -with-rtsopts "-N"

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,13 +1,13 @@
 cabal-version: 2.4
 name:          process-tests
-version:       1.6.18.0
+version:       1.6.19.0
 license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
 bug-reports:   https://github.com/haskell/process/issues
 synopsis:      Testing package for the process library
 category:      System
-build-type:    Simple
+build-type:    Custom
 description:
     This package contains the testing infrastructure for the process library
 
@@ -16,15 +16,39 @@ source-repository head
   location: https://github.com/haskell/process.git
   subdir:   test
 
+common process-dep
+  build-depends:
+    process == 1.6.19.0
+
+custom-setup
+  setup-depends:
+    base      >= 4.10 && < 4.20,
+    directory >= 1.1  && < 1.4,
+    filepath  >= 1.2  && < 1.6,
+    Cabal     >= 2.4  && < 3.12,
+
+-- Test executable for the CommunicationHandle functionality
+executable cli-child
+  import: process-dep
+  default-language: Haskell2010
+  hs-source-dirs: cli-child
+  main-is: main.hs
+  build-depends: base >= 4 && < 5
+               , deepseq >= 1.1 && < 1.6
+  ghc-options: -threaded -rtsopts
+
 test-suite test
+  import: process-dep
   default-language: Haskell2010
   hs-source-dirs: .
   main-is: main.hs
   type: exitcode-stdio-1.0
   build-depends: base >= 4 && < 5
-               , bytestring
-               , deepseq
-               , directory
-               , filepath
-               , process == 1.6.18.0
+               , bytestring >= 0.11 && < 0.13
+               , deepseq  >= 1.1 && < 1.6
+               , directory >= 1.1 && < 1.4
+               , filepath >= 1.2 && < 1.6
+  build-tool-depends: process-tests:cli-child
   ghc-options: -threaded -rtsopts -with-rtsopts "-N"
+  other-modules: Test.Paths
+  autogen-modules: Test.Paths

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -21,8 +21,6 @@ test-suite test
   hs-source-dirs: .
   main-is: main.hs
   type: exitcode-stdio-1.0
-  -- Add otherwise redundant bounds on base since GHC's build system runs
-  -- `cabal check`, which mandates bounds on base.
   build-depends: base >= 4 && < 5
                , bytestring
                , deepseq

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,9 +1,0 @@
-resolver: ghc-9.2.3
-
-extra-deps:
-  - ..
-  - Cabal-3.10.2.0
-
-allow-newer: True
-allow-newer-deps:
-  - Cabal

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,0 +1,9 @@
+resolver: ghc-9.2.3
+
+extra-deps:
+  - ..
+  - Cabal-3.10.2.0
+
+allow-newer: True
+allow-newer-deps:
+  - Cabal


### PR DESCRIPTION
NB: Only look at the diff compared to #308, i.e. the last commit (as of writing this description, this was: 79cf59aaeb66921884a841d39f1fd5232e19f474).

@Mistuke suggested on [the GHC issue tracker](https://gitlab.haskell.org/ghc/ghc/-/issues/24618#note_555997) that, when communicating via a named pipe on Windows, if the child process wants to use asynchronous I/O, it should re-open the handle that it was passed with the overlap flag set.  
I attempt to do that in this PR, but it seems this operation always fails with a "invalid permissions" error. Discussing with @bgamari, we came to the conclusion that Windows does not seem to allow re-opening one end of a pipe created with `mkNamedPipe` unless one is using the listen-style `ConnectPipe` API (that we are deliberately not using). See e.g. [this StackOverflow answer](https://stackoverflow.com/posts/31701979/revisions) which says:

> You did specify PIPE_UNLIMITED_INSTANCES for the nMaxInstances parameter in CreateNamedPipe call, but as you never called ConnectNamedPipe to create other endpoints, only one CreateFile was allowed.

@Mistuke, are we missing something? Is there a way to call re-open file in this situation that is expected to work?