### PR TITLE
Move tests to separate process-tests package & update CI to use GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,47 +3,114 @@ name: Tests
 on:
     pull_request:
     push:
-        branches:
-        - master
+      branches:
+        - '**'
 
 jobs:
   build:
-    name: CI
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        args:
-        - "--resolver ghc-9.8.1"
-        - "--resolver ghc-9.6.3"
-        - "--resolver ghc-9.4.7"
-        - "--resolver ghc-9.2.8"
-        - "--resolver ghc-9.0.1"
-        - "--resolver ghc-8.10.4"
-        - "--resolver ghc-8.8.4"
-        - "--resolver ghc-8.6.5"
-        - "--resolver ghc-8.4.4"
-        - "--resolver ghc-8.2.2"
+        ghc-version:
+          - 'latest'
+          - '9.8'
+          - '9.6'
+          - '9.4'
+          - '9.2'
+          - '9.0'
+          - '8.10'
+          - '8.8'
+          - '8.6'
+          - '8.4'
+          - '8.2'
+
+        exclude:
+          # Exclude GHC 8.2 on Windows (GHC bug: undefined reference to `__stdio_common_vswprintf_s')
+          - os: windows-latest
+            ghc-version: '8.2'
 
     steps:
-      - name: Clone project
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Build and run tests
-        shell: bash
+      - name: Set up GHC ${{ matrix.ghc-version }}
+        uses: haskell-actions/setup@v2
+        id: setup
+        with:
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
+          cabal-version: 'latest'
+          cabal-update: true
+
+      - name: Set up autotools (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            autotools
+
+      - name: Run autoreconf (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: autoreconf -i
+        shell: "msys2 {0}"
+
+      - name: Run autoreconf (Linux & Mac)
+        if: ${{ runner.os != 'Windows' }}
+        run: autoreconf -i
+
+      - name: Configure the build
         run: |
-            set -ex
-            stack upgrade
-            stack --version
-            if [[ "${{ runner.os }}" = 'Windows' ]]
-            then
-              # Looks like a bug in Stack, this shouldn't break things
-              ls C:/ProgramData/Chocolatey/bin/
-              rm -rf C:/ProgramData/Chocolatey/bin/ghc*
-              stack ${{ matrix.args }} exec pacman -- --sync --refresh --noconfirm autoconf
-            fi
-            stack build
-            stack sdist --test-tarball
-            cd test
-            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v3
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build process --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v3
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
+      - name: Build
+        run: cabal build process
+
+      - name: Run tests
+        run: cabal run process-tests:test
+
+        # On Windows and with GHC >= 9.0, re-run the test-suite using WinIO.
+      - name: Re-run tests with WinIO (Windows && GHC >= 9.0)
+        if: ${{ runner.os == 'Windows' && matrix.ghc-version >= '9.0' }}
+        run: cabal run process-tests:test -- +RTS --io-manager=native -RTS
+
+      - name: Source dist
+        run: cabal sdist all --ignore-project
+
+      - name: Build documentation
+        run: cabal haddock process
+
+      - name: Check process.cabal
+        run: cabal check
+
+      - name: Check process-tests.cabal
+        working-directory: ./test
+        run: cabal check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,7 @@ jobs:
               rm -rf C:/ProgramData/Chocolatey/bin/ghc*
               stack ${{ matrix.args }} exec pacman -- --sync --refresh --noconfirm autoconf
             fi
-            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}
+            stack build
             stack sdist --test-tarball
+            cd test
+            stack test --bench --no-run-benchmarks --haddock --no-terminal ${{ matrix.args }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-/.cabal-sandbox/
-/cabal.project.local
-/cabal.sandbox.config
-/dist/
-/dist-newstyle/
-/.stack-work/
+**/.cabal-sandbox/
+**/cabal.project.local
+**/cabal.sandbox.config
+**/dist/
+**/dist-newstyle/
+**/.stack-work/
 *.swp
+stack.yaml.lock
 
 # Specific generated files
 GNUmakefile

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,11 @@
 module Main (main) where
 
 import Distribution.Simple
+  ( defaultMainWithHooks
+  , autoconfUserHooks
+  )
+
+--------------------------------------------------------------------------------
 
 main :: IO ()
 main = defaultMainWithHooks autoconfUserHooks

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -105,13 +105,12 @@ import System.IO.Error (mkIOError, ioeSetErrorString)
 
 #if defined(javascript_HOST_ARCH)
 import System.Process.JavaScript(getProcessId, getCurrentProcessId)
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 import System.Win32.Process (getProcessId, getCurrentProcessId, ProcessId)
 #else
 import System.Posix.Process (getProcessID)
 import System.Posix.Types (CPid (..))
 #endif
-
 import GHC.IO.Exception ( ioException, IOErrorType(..), IOException(..) )
 
 #if defined(wasm32_HOST_ARCH)
@@ -126,7 +125,7 @@ import System.IO.Error
 -- @since 1.6.3.0
 #if defined(javascript_HOST_ARCH)
 type Pid = Int
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 type Pid = ProcessId
 #else
 type Pid = CPid
@@ -668,7 +667,7 @@ getPid (ProcessHandle mh _ _) = do
     OpenHandle h -> do
       pid <- getProcessId h
       return $ Just pid
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
     OpenHandle h -> do
       pid <- getProcessId h
       return $ Just pid
@@ -691,7 +690,7 @@ getCurrentPid :: IO Pid
 getCurrentPid =
 #if defined(javascript_HOST_ARCH)
     getCurrentProcessId
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
     getCurrentProcessId
 #else
     getProcessID
@@ -743,7 +742,7 @@ waitForProcess ph@(ProcessHandle _ delegating_ctlc _) = lockWaitpid $ do
         when (was_open && delegating_ctlc) $
           endDelegateControlC e
         return e'
-#if defined(WINDOWS)
+#if defined(mingw32_HOST_OS)
     OpenExtHandle h job -> do
         -- First wait for completion of the job...
         waitForJobCompletion job
@@ -872,7 +871,7 @@ terminateProcess ph = do
   withProcessHandle ph $ \p_ ->
     case p_ of
       ClosedHandle  _ -> return ()
-#if defined(WINDOWS)
+#if defined(mingw32_HOST_OS)
       OpenExtHandle{} -> terminateJobUnsafe p_ 1 >> return ()
 #else
       OpenExtHandle{} -> error "terminateProcess with OpenExtHandle should not happen on POSIX."

--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -21,7 +21,7 @@ module System.Process.Common
     , pfdToHandle
 
 -- Avoid a warning on Windows
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     , CGid (..)
 #else
     , CGid
@@ -63,7 +63,7 @@ import GHC.JS.Prim (JSVal)
 
 -- We do a minimal amount of CPP here to provide uniform data types across
 -- Windows and POSIX.
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
 import Data.Word (Word32)
 import System.Win32.DebugApi (PHANDLE)
 #if defined(__IO_MANAGER_WINIO__)
@@ -75,7 +75,7 @@ import System.Posix.Types
 
 #if defined(javascript_HOST_ARCH)
 type PHANDLE = JSVal
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 -- Define some missing types for Windows compatibility. Note that these values
 -- will never actually be used, as the setuid/setgid system calls are not
 -- applicable on Windows. No value of this type will ever exist.

--- a/System/Process/Internals.hs
+++ b/System/Process/Internals.hs
@@ -22,7 +22,7 @@
 module System.Process.Internals (
     ProcessHandle(..), ProcessHandle__(..),
     PHANDLE, closePHANDLE, mkProcessHandle,
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     CGid(..),
 #else
     CGid,
@@ -39,7 +39,7 @@ module System.Process.Internals (
     endDelegateControlC,
     stopDelegateControlC,
     unwrapHandles,
-#ifdef WINDOWS
+#if defined(mingw32_HOST_OS)
     terminateJob,
     terminateJobUnsafe,
     waitForJobCompletion,
@@ -68,7 +68,7 @@ import System.Process.Common
 
 #if defined(javascript_HOST_ARCH)
 import System.Process.JavaScript
-#elif defined(WINDOWS)
+#elif defined(mingw32_HOST_OS)
 import System.Process.Windows
 #else
 import System.Process.Posix

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ., test

--- a/process.cabal
+++ b/process.cabal
@@ -1,14 +1,14 @@
+cabal-version: 2.4
 name:          process
 version:       1.6.19.0
 -- NOTE: Don't forget to update ./changelog.md
-license:       BSD3
+license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
 bug-reports:   https://github.com/haskell/process/issues
 synopsis:      Process libraries
 category:      System
 build-type:    Configure
-cabal-version: >=1.10
 description:
     This package contains libraries for dealing with system processes.
     .
@@ -18,9 +18,11 @@ description:
     read more about it at
     <https://github.com/fpco/typed-process/#readme>.
 
+extra-doc-files:
+    changelog.md
+
 extra-source-files:
     aclocal.m4
-    changelog.md
     configure
     configure.ac
     include/HsProcessConfig.h.in
@@ -90,19 +92,3 @@ library
                    directory >= 1.1 && < 1.4,
                    filepath  >= 1.2 && < 1.6,
                    deepseq   >= 1.1 && < 1.6
-
-test-suite test
-  default-language: Haskell2010
-  hs-source-dirs: test
-  main-is: main.hs
-  type: exitcode-stdio-1.0
-  -- Add otherwise redundant bounds on base since GHC's build system runs
-  -- `cabal check`, which mandates bounds on base.
-  build-depends: base >= 4 && < 5
-               , bytestring
-               , directory
-               , process
-  ghc-options: -threaded
-               -with-rtsopts "-N"
-  if os(windows)
-        cpp-options: -DWINDOWS

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,12 @@
 resolver: ghc-9.2.3
+
+packages:
+  - .
+  - test
+
+extra-deps:
+  - Cabal-3.6.3.0
+
+allow-newer: True
+allow-newer-deps:
+  - Cabal

--- a/test/LICENSE
+++ b/test/LICENSE
@@ -1,0 +1,31 @@
+Copyright (c) 2024, the Haskell process developers.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Isaac Jones nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/test/main.hs
+++ b/test/main.hs
@@ -22,7 +22,7 @@ ifWindows action
   | otherwise     = action
 
 isWindows :: Bool
-#if WINDOWS
+#if defined(mingw32_HOST_OS)
 isWindows = True
 #else
 isWindows = False

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -21,8 +21,6 @@ test-suite test
   hs-source-dirs: .
   main-is: main.hs
   type: exitcode-stdio-1.0
-  -- Add otherwise redundant bounds on base since GHC's build system runs
-  -- `cabal check`, which mandates bounds on base.
   build-depends: base >= 4 && < 5
                , bytestring
                , deepseq

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,0 +1,32 @@
+cabal-version: 2.4
+name:          process-tests
+version:       1.6.19.0
+license:       BSD-3-Clause
+license-file:  LICENSE
+maintainer:    libraries@haskell.org
+bug-reports:   https://github.com/haskell/process/issues
+synopsis:      Testing package for the process library
+category:      System
+build-type:    Simple
+description:
+    This package contains the testing infrastructure for the process library
+
+source-repository head
+  type:     git
+  location: https://github.com/haskell/process.git
+  subdir:   test
+
+test-suite test
+  default-language: Haskell2010
+  hs-source-dirs: .
+  main-is: main.hs
+  type: exitcode-stdio-1.0
+  -- Add otherwise redundant bounds on base since GHC's build system runs
+  -- `cabal check`, which mandates bounds on base.
+  build-depends: base >= 4 && < 5
+               , bytestring
+               , deepseq
+               , directory
+               , filepath
+               , process == 1.6.19.0
+  ghc-options: -threaded -rtsopts -with-rtsopts "-N"

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,9 +1,0 @@
-resolver: ghc-9.2.3
-
-extra-deps:
-  - ..
-  - Cabal-3.10.2.0
-
-allow-newer: True
-allow-newer-deps:
-  - Cabal

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,0 +1,9 @@
+resolver: ghc-9.2.3
+
+extra-deps:
+  - ..
+  - Cabal-3.10.2.0
+
+allow-newer: True
+allow-newer-deps:
+  - Cabal


### PR DESCRIPTION
The first commit moves the test-suite to a separate package. The rationale is that other work, such as #308, requires the test-suite to use a Custom setup in order to work around [Cabal bug #9854](https://github.com/haskell/cabal/issues/9854). If we don't split up the test-suite into a separate package, this would introduce a setup-depends dependency on the Cabal library, which would create a gnarly dependency cycle between `Cabal` and `process`.

The second commit rewrites the CI script. I did this because I couldn't figure out how to provision the `Cabal` library (needed by #308) across GHC versions with the current CI infrastructure.

There are a few other auxiliary changes, such as:

  - Using Cabal version >= 2.4 in the .cabal files, and fixing the associated warnings,
  - Using the CPP mingw32_HOST_OS define to check for Windows;
    this avoids having to define the same variable twice in two different packages.