### PR TITLE
Bump to base < 4.21 (to support GHC 9.10)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
           - { os: windows-latest, arch: x64 }
         ghc-version:
           - 'latest'
+          - '9.10'
           - '9.8'
           - '9.6'
           - '9.4'

--- a/process.cabal
+++ b/process.cabal
@@ -90,7 +90,7 @@ library
 
     ghc-options: -Wall
 
-    build-depends: base      >= 4.10 && < 4.20,
+    build-depends: base      >= 4.10 && < 4.21,
                    directory >= 1.1 && < 1.4,
                    filepath  >= 1.2 && < 1.6,
                    deepseq   >= 1.1 && < 1.6

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -22,7 +22,7 @@ common process-dep
 
 custom-setup
   setup-depends:
-    base      >= 4.10 && < 4.20,
+    base      >= 4.10 && < 4.21,
     directory >= 1.1  && < 1.4,
     filepath  >= 1.2  && < 1.6,
     Cabal     >= 2.4  && < 3.12,


### PR DESCRIPTION
I don't know what we should do about testing this, since `haskell-actions` doesn't have 9.10 yet. Should we wait for it to do so?

(Relatedly, I'm surprised that, since `process` is a boot library, that GHC could even release without this bump having already been performed. Maybe GHC just doesn't look at cabal version bounds at all.)