### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -82,8 +82,6 @@ library
             build-depends: unix >= 2.5 && < 2.9
 
     include-dirs: include
-    includes:
-        runProcess.h
     install-includes:
         runProcess.h
         processFlags.h


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355