### PR TITLE
Don't attach finalizers to Handles in CommunicationHandle API

### DIFF
--- a/System/Process/CommunicationHandle.hs
+++ b/System/Process/CommunicationHandle.hs
@@ -38,12 +38,18 @@ import Control.DeepSeq (NFData, rnf)
 -- | Turn the 'CommunicationHandle' into a 'Handle' that can be read from
 -- in the current process.
 --
+-- The returned 'Handle' does not have any finalizers attached to it;
+-- use 'hClose' to close it.
+--
 -- @since 1.6.20.0
 openCommunicationHandleRead :: CommunicationHandle -> IO Handle
 openCommunicationHandleRead = useCommunicationHandle True
 
 -- | Turn the 'CommunicationHandle' into a 'Handle' that can be written to
 -- in the current process.
+--
+-- The returned 'Handle' does not have any finalizers attached to it;
+-- use 'hClose' to close it.
 --
 -- @since 1.6.20.0
 openCommunicationHandleWrite :: CommunicationHandle -> IO Handle
@@ -54,6 +60,9 @@ openCommunicationHandleWrite = useCommunicationHandle False
 
 -- | Create a pipe @(weRead,theyWrite)@ that the current process can read from,
 -- and whose write end can be passed to a child process in order to receive data from it.
+--
+-- The returned 'Handle' does not have any finalizers attached to it;
+-- use 'hClose' to close it.
 --
 -- See 'CommunicationHandle'.
 --
@@ -70,6 +79,9 @@ createWeReadTheyWritePipe =
 
 -- | Create a pipe @(theyRead,weWrite)@ that the current process can write to,
 -- and whose read end can be passed to a child process in order to send data to it.
+--
+-- The returned 'Handle' does not have any finalizers attached to it;
+-- use 'hClose' to close it.
 --
 -- See 'CommunicationHandle'.
 --
@@ -125,6 +137,7 @@ readCreateProcessWithExitCodeCommunicationHandle mkProg readAction writeAction =
   let cp = mkProg (chTheyRead, chTheyWrite)
   -- The following implementation parallels 'readCreateProcess'
   withCreateProcess cp $ \ _ _ _ ph -> do
+
     -- Close the parent's references to the 'CommunicationHandle's after they
     -- have been inherited by the child (we don't want to keep pipe ends open).
     closeCommunicationHandle chTheyWrite

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## 1.6.21.0 *July 2024*
+
+* No longer attach finalizers to `Handle`s created by the
+  `System.Process.CommunicationHandle` API. Instead, all file descriptors are
+  manually closed by the API.
+
+  This fixes a bug in which a file descriptor could be closed multiple times.
+
 ## 1.6.20.0 *April 2024*
 
 * Introduce `System.Process.CommunicationHandle`, allowing for platform-independent

--- a/process.cabal
+++ b/process.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process
-version:       1.6.20.0
+version:       1.6.21.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process-tests
-version:       1.6.20.0
+version:       1.6.21.0
 license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
@@ -18,14 +18,14 @@ source-repository head
 
 common process-dep
   build-depends:
-    process == 1.6.20.0
+    process == 1.6.21.0
 
 custom-setup
   setup-depends:
     base      >= 4.10 && < 4.21,
     directory >= 1.1  && < 1.4,
     filepath  >= 1.2  && < 1.6,
-    Cabal     >= 2.4  && < 3.12,
+    Cabal     >= 2.4  && < 3.14,
 
 -- Test executable for the CommunicationHandle functionality
 executable cli-child


### PR DESCRIPTION
We are now careful to not attach any finalizers to Handles when creating pipes for inter-process communication on Unix systems. Instead, the handles are closed manually.

The finalizers were causing problems in situations such as the following:

  - the parent creates a new pipe, e.g. pipe2([7,8]),
  - the parent spawns a child process, and lets FD 8 be inherited by the child,
  - the parent closes FD 8 (as it should),
  - the parent opens FD 8 for some other purpose, e.g. for writing to a file,
  - the finalizer for the Handle wrapping FD 8 runs, closing FD 8, even though it is now in use for a completely different purpose.

This PR does not include a test, as the above bug is a bit difficult to trigger. My reproducer for this bug was a test in the `cabal-install` testsuite; I can confirm that the bug no longer occurs with this patch.

This PR bumps the process version to `1.6.21.0`. After releasing it on Hackage, I would also recommend deprecating `1.6.20.0`.