### PR TITLE
Use correct version of process in process-tests

### DIFF
--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 common process-dep
   build-depends:
-    process == 1.6.21.0
+    process == 1.6.22.0
 
 custom-setup
   setup-depends:


### PR DESCRIPTION
Following up from the release of 1.6.22.0