### PR TITLE
Prevent command-line injection for batch files with trailing char

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## 1.6.23.0 *September 2024*
+
+* Fix command-line escaping logic on Windows when the command file ends with
+  a space or a dot. This is a follow-up for
+  [HSEC-2024-0003](https://github.com/haskell/security-advisories/tree/main/advisories/hackage/process/HSEC-2024-0003.md).
+
 ## 1.6.22.0 *August 2024*
 
 * Allow NUL to appear in arguments under POSIX. See

--- a/process.cabal
+++ b/process.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process
-version:       1.6.22.0
+version:       1.6.23.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process-tests
-version:       1.6.21.0
+version:       1.6.23.0
 license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
@@ -18,7 +18,7 @@ source-repository head
 
 common process-dep
   build-depends:
-    process == 1.6.22.0
+    process == 1.6.23.0
 
 custom-setup
   setup-depends:


### PR DESCRIPTION
This change ensure the regime implemented for HSEC-2024-0003 is applied to batch file names ending with trailing chars that are ignored by Windows.