### PR TITLE
Correctly detect posix_spawn_file_actions_addchdir[_np]

### DIFF
--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -1,3 +1,7 @@
+// Necessary for POSIX_SPAWN_SETSID and posix_spawn_file_actions_addchdir_np under glibc.
+// Moreover this needs to appear before any glibc headers.
+#define _GNU_SOURCE
+
 #include "runProcess.h"
 #include "common.h"
 
@@ -25,8 +29,6 @@ do_spawn_posix (char *const args[],
 
 #else
 
-// Necessary for POSIX_SPAWN_SETSID under glibc.
-#define _GNU_SOURCE
 #include <spawn.h>
 
 extern char **environ;
@@ -135,13 +137,13 @@ do_spawn_posix (char *const args[],
     }
 
     if (workingDirectory) {
-#if defined(HAVE_posix_spawn_file_actions_addchdir)
+#if defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR)
         r = posix_spawn_file_actions_addchdir(&fa, workingDirectory);
         if (r != 0) {
             *failed_doing = "posix_spawn_file_actions_addchdir";
             goto fail;
         }
-#elif defined(HAVE_posix_spawn_file_actions_addchdir_np)
+#elif defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP)
         // N.B. this function is broken on macOS.
         // See https://github.com/rust-lang/rust/pull/80537.
         r = posix_spawn_file_actions_addchdir_np(&fa, workingDirectory);


### PR DESCRIPTION
Fixes #303. The previous fix in #304 unfortunately didn't resolve the issue, but I've tested with `strace` that this patch results in the right syscall.

It appears that CPP macro names are case sensitive, and the code was previously checking for `HAVE_posix_spawn_file_actions_addchdir` whereas Autoconf defines `HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR`. This meant that calls to `createProcess` which set `cwd` to a `Just` value would always fail to use `posix_spawn` and instead fall back on `fork`, which is problematic when the parent process has a large residency.

Testing the fix revealed another issue, which is that `_GNU_SOURCE` must be defined before any glibc headers are included, otherwise the `_np` variant provided by glibc will not be declared.