### PR TITLE
Fix build with  Javascript backend

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## 1.6.25.0 *September 2024*
+
+* Fix build with Javascript backend ([#327](https://github.com/haskell/process/issues/327))
+
 ## 1.6.24.0 *September 2024*
 
 * Fix detection of `posix_spawn_file_actions_addchdir[_np]` ([#303](https://github.com/haskell/process/issues/303))

--- a/process.cabal
+++ b/process.cabal
@@ -68,6 +68,7 @@ library
         extra-libraries: kernel32, ole32, rpcrt4
         cpp-options: -DWINDOWS
     else
+        build-depends: unix >= 2.5 && < 2.9
         if arch(javascript)
             js-sources:
                 jsbits/process.js
@@ -79,7 +80,6 @@ library
                 cbits/posix/posix_spawn.c
                 cbits/posix/find_executable.c
             other-modules: System.Process.Posix
-            build-depends: unix >= 2.5 && < 2.9
 
     include-dirs: include
     install-includes:

--- a/process.cabal
+++ b/process.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process
-version:       1.6.24.0
+version:       1.6.25.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD-3-Clause
 license-file:  LICENSE


### PR DESCRIPTION
The new `CommunicationsHandle` abstraction requires the `setFdOptions` from `unix`.
    
Fixes #327.
