### PR TITLE
Support being configured without fork

### DIFF
--- a/cbits/posix/common.h
+++ b/cbits/posix/common.h
@@ -30,6 +30,7 @@ char *find_executable(char *workingDirectory, char *filename);
 #endif
 
 // defined in fork_exec.c
+#if defined(HAVE_FORK)
 ProcHandle
 do_spawn_fork (char *const args[],
                char *workingDirectory, char **environment,
@@ -39,6 +40,7 @@ do_spawn_fork (char *const args[],
                gid_t *childGroup, uid_t *childUser,
                int flags,
                char **failed_doing);
+#endif
 
 // defined in posix_spawn.c
 ProcHandle

--- a/cbits/posix/runProcess.c
+++ b/cbits/posix/runProcess.c
@@ -7,8 +7,6 @@
 #include "runProcess.h"
 #include "common.h"
 
-#if defined(HAVE_FORK)
-
 #include <unistd.h>
 #include <errno.h>
 #include <sys/wait.h>
@@ -70,6 +68,7 @@ do_spawn (char *const args[],
         return r;
     }
 
+#if defined(HAVE_FORK)
     r = do_spawn_fork(args,
                       workingDirectory, environment,
                       stdInHdl, stdOutHdl, stdErrHdl,
@@ -77,6 +76,11 @@ do_spawn (char *const args[],
                       flags,
                       failed_doing);
     return r;
+#else
+    *failed_doing = "fork";
+    return -1;
+#endif
+
 }
 
 enum pipe_direction {
@@ -267,5 +271,3 @@ waitForProcess (ProcHandle handle, int *pret)
 
     return -1;
 }
-
-#endif // HAVE_FORK


### PR DESCRIPTION
Fixes #342. Prior to this change, configuring with `ac_cv_func_fork=no` would result in linker errors due to missing symbols. By moving the `HAVE_FORK` checks, configuring with  `ac_cv_func_fork=no`  now results in `do_spawn` failing at runtime if the `fork` path is needed (e.g. if `posix_spawn` was not supported).