### PR TITLE
Support Cabal 3.16 (only)

### DIFF
--- a/test/Setup.hs
+++ b/test/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 
 module Main (main) where
@@ -31,6 +32,10 @@ import Distribution.Types.TargetInfo
   ( targetComponent )
 import Distribution.Types.UnqualComponentName
   ( unUnqualComponentName )
+#if MIN_VERSION_Cabal(3,16,0)
+import Distribution.Utils.Path
+  ( SymbolicPathX, interpretSymbolicPathCWD)
+#endif
 
 -- directory
 import System.Directory
@@ -45,6 +50,15 @@ import System.FilePath
 main :: IO ()
 main = defaultMainWithHooks testProcessHooks
 
+#if MIN_VERSION_Cabal(3,16,0)
+pathToString ::
+  SymbolicPathX allowAbsolute from to -> String
+pathToString = interpretSymbolicPathCWD
+#else
+pathToString :: String -> String
+pathToString = id
+#endif
+
 -- The following code works around Cabal bug #9854.
 --
 -- The process-tests package has an executable component named "cli-child",
@@ -57,7 +71,7 @@ testProcessHooks =
   simpleUserHooks
     { buildHook = \ pd lbi userHooks buildFlags ->
         withTestLBI pd lbi $ \ _testSuite clbi -> do
-          let pathsFile = autogenComponentModulesDir lbi clbi </> "Test" </> "Paths" <.> "hs"
+          let pathsFile = pathToString (autogenComponentModulesDir lbi clbi) </> "Test" </> "Paths" <.> "hs"
           createDirectoryIfMissing True (takeDirectory pathsFile)
           writeFile pathsFile $ unlines
             [ "module Test.Paths where"
@@ -74,6 +88,6 @@ processInternalExes pd lbi =
   , CExe exe <- [targetComponent tgt]
   , let toolName = unUnqualComponentName $ exeName exe
         toolLocation =
-          buildDir lbi
+          pathToString (buildDir lbi)
             </> (toolName </> toolName <.> exeExtension (hostPlatform lbi))
   ]

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -25,7 +25,7 @@ custom-setup
     base      >= 4.10 && < 4.23,
     directory >= 1.1  && < 1.4,
     filepath  >= 1.2  && < 1.6,
-    Cabal     >= 2.4  && < 3.14,
+    Cabal     >= 2.4  && < 3.18,
 
 -- Test executable for the CommunicationHandle functionality
 executable cli-child


### PR DESCRIPTION
The Cabal API broke in 3.16 so supporting 3.16 and older versions would require some form of conditional compilation

@bgamari , are you OK with this?  @sheaf, you wrote this, what do you think?

Github runners seem to have migrated to 3.16 and I can't merge https://github.com/haskell/process/pull/352 until we have a fix in place. I'm OK with finding some way (maybe CPP) of widening the bound again later. Since this is just for tests I don't think it's critical.