### PR TITLE
Fix changelog; release 1.6.27.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,8 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
-## 1.6.26.2 *March 2026*
+## 1.6.27.0 *March 2026*
 
+* Support being configured without fork
 * Fix `@since` annotations
 
 ## 1.6.26.1 *May 2025*

--- a/process.cabal
+++ b/process.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process
-version:       1.6.26.2
+version:       1.6.27.0
 -- NOTE: Don't forget to update ./changelog.md
 license:       BSD-3-Clause
 license-file:  LICENSE

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.4
 name:          process-tests
-version:       1.6.26.2
+version:       1.6.27.0
 license:       BSD-3-Clause
 license-file:  LICENSE
 maintainer:    libraries@haskell.org
@@ -18,7 +18,7 @@ source-repository head
 
 common process-dep
   build-depends:
-    process == 1.6.26.2
+    process == 1.6.27.0
 
 custom-setup
   setup-depends:


### PR DESCRIPTION
1.6.26.2 was PVP-violating so will be marked as a deprecated version