### PR TITLE
Add `callCreateProcess`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         platform:
           - { os: ubuntu-latest, arch: x64 }
-          - { os: macos-13, arch: x64 }
+          - { os: macos-14, arch: x64 }
           - { os: macos-14, arch: arm }
           - { os: windows-latest, arch: x64 }
         ghc-version:

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -352,26 +352,15 @@ spawnCommand cmd = do
 callCreateProcess :: CreateProcess -> IO ()
 callCreateProcess = callCreateProcess_ "callCreateProcess"
 
--- | Creates a new process to run the specified command with the given
--- arguments, and wait for it to finish.  If the command returns a non-zero
--- exit code, an exception is raised.
---
--- If an asynchronous exception is thrown to the thread executing
--- @callProcess@, the forked process will be terminated and
--- @callProcess@ will wait (block) until the process has been
--- terminated.
+-- | \"@callProcess cmd args@\" is a shorthand for
+-- \"@'callCreateProcess' ('proc' cmd args)@\".
 --
 -- @since 1.2.0.0
 callProcess :: FilePath -> [String] -> IO ()
 callProcess cmd = callCreateProcess_ "callProcess" . proc cmd
 
--- | Creates a new process to run the specified shell command.  If the
--- command returns a non-zero exit code, an exception is raised.
---
--- If an asynchronous exception is thrown to the thread executing
--- @callCommand@, the forked process will be terminated and
--- @callCommand@ will wait (block) until the process has been
--- terminated.
+-- | \"@callCommand cmd@\" is a shorthand for \"@'callCreateProcess'
+-- ('shell' cmd)@\".
 --
 -- @since 1.2.0.0
 callCommand :: String -> IO ()

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -349,7 +349,7 @@ spawnCommand cmd = do
 --
 -- @since 1.2.0.0
 callProcess :: FilePath -> [String] -> IO ()
-callProcess cmd args = callCreateProcess_ "callProcess" (proc cmd args)
+callProcess cmd = callCreateProcess_ "callProcess" . proc cmd
 
 -- | Creates a new process to run the specified shell command.  If the
 -- command returns a non-zero exit code, an exception is raised.

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -574,8 +574,9 @@ readCreateProcess cp input = do
 
     case ex of
      ExitSuccess   -> return output
-     ExitFailure r -> processFailedException "readCreateProcess" cmd args r
+     ExitFailure r -> processFailedException fun cmd args r
   where
+    fun = "readCreateProcess"
     (cmd, args) = case cp of
             CreateProcess { cmdspec = ShellCommand sc } -> (sc, [])
             CreateProcess { cmdspec = RawCommand fp args' } -> (fp, args')

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -349,8 +349,7 @@ spawnCommand cmd = do
 --
 -- @since 1.2.0.0
 callProcess :: FilePath -> [String] -> IO ()
-callProcess cmd args = do
-    callCreateProcess_ "callProcess" (proc cmd args)
+callProcess cmd args = callCreateProcess_ "callProcess" (proc cmd args)
 
 -- | Creates a new process to run the specified shell command.  If the
 -- command returns a non-zero exit code, an exception is raised.

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -574,12 +574,14 @@ readCreateProcess cp input = do
 
     case ex of
      ExitSuccess   -> return output
-     ExitFailure r -> processFailedException fun cmd args r
+     ExitFailure r -> processFailed r
   where
     fun = "readCreateProcess"
-    (cmd, args) = case cp of
-            CreateProcess { cmdspec = ShellCommand sc } -> (sc, [])
-            CreateProcess { cmdspec = RawCommand fp args' } -> (fp, args')
+    processFailed = case cp of
+            CreateProcess { cmdspec = ShellCommand sc } ->
+              processFailedException fun sc []
+            CreateProcess { cmdspec = RawCommand fp args' } ->
+              processFailedException fun fp args'
 
 
 -- | @readProcessWithExitCode@ is like 'readProcess' but with two differences:

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -356,7 +356,7 @@ callProcess cmd args = do
                    waitForProcess p
     case exit_code of
       ExitSuccess   -> return ()
-      ExitFailure r -> processFailedException "callProcess" cmd args r
+      ExitFailure r -> processFailed "callProcess" (cmdspec command) r
 
 -- | Creates a new process to run the specified shell command.  If the
 -- command returns a non-zero exit code, an exception is raised.

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -368,8 +368,9 @@ callProcess cmd args = do
 -- @since 1.2.0.0
 callCommand :: String -> IO ()
 callCommand cmd = do
+    let command = shell cmd
     exit_code <- withCreateProcess_ "callCommand"
-                   (shell cmd) { delegate_ctlc = True } $ \_ _ _ p ->
+                   command { delegate_ctlc = True } $ \_ _ _ p ->
                    waitForProcess p
     case exit_code of
       ExitSuccess   -> return ()

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -580,9 +580,7 @@ readCreateProcess cp input = do
 
     case ex of
      ExitSuccess   -> return output
-     ExitFailure r -> processFailed fun (cmdspec cp) r
-  where
-    fun = "readCreateProcess"
+     ExitFailure r -> processFailed "readCreateProcess" (cmdspec cp) r
 
 
 -- | @readProcessWithExitCode@ is like 'readProcess' but with two differences:

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -351,12 +351,7 @@ spawnCommand cmd = do
 callProcess :: FilePath -> [String] -> IO ()
 callProcess cmd args = do
     let command = proc cmd args
-    exit_code <- withCreateProcess_ "callProcess"
-                   command { delegate_ctlc = True } $ \_ _ _ p ->
-                   waitForProcess p
-    case exit_code of
-      ExitSuccess   -> return ()
-      ExitFailure r -> processFailed "callProcess" (cmdspec command) r
+    callCreateProcess_ "callProcess" command
 
 -- | Creates a new process to run the specified shell command.  If the
 -- command returns a non-zero exit code, an exception is raised.
@@ -370,12 +365,16 @@ callProcess cmd args = do
 callCommand :: String -> IO ()
 callCommand cmd = do
     let command = shell cmd
-    exit_code <- withCreateProcess_ "callCommand"
+    callCreateProcess_ "callCommand" command
+
+callCreateProcess_ :: String -> CreateProcess -> IO ()
+callCreateProcess_ fun command = do
+    exit_code <- withCreateProcess_ fun
                    command { delegate_ctlc = True } $ \_ _ _ p ->
                    waitForProcess p
     case exit_code of
       ExitSuccess   -> return ()
-      ExitFailure r -> processFailed "callCommand" (cmdspec command) r
+      ExitFailure r -> processFailed fun (cmdspec command) r
 
 processFailed :: String -> CmdSpec -> Int -> IO a
 processFailed fun = \ case

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -350,8 +350,9 @@ spawnCommand cmd = do
 -- @since 1.2.0.0
 callProcess :: FilePath -> [String] -> IO ()
 callProcess cmd args = do
+    let command = proc cmd args
     exit_code <- withCreateProcess_ "callProcess"
-                   (proc cmd args) { delegate_ctlc = True } $ \_ _ _ p ->
+                   command { delegate_ctlc = True } $ \_ _ _ p ->
                    waitForProcess p
     case exit_code of
       ExitSuccess   -> return ()

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -576,12 +576,9 @@ readCreateProcess cp input = do
      ExitSuccess   -> return output
      ExitFailure r -> processFailedException "readCreateProcess" cmd args r
   where
-    cmd = case cp of
-            CreateProcess { cmdspec = ShellCommand sc } -> sc
-            CreateProcess { cmdspec = RawCommand fp _ } -> fp
-    args = case cp of
-             CreateProcess { cmdspec = ShellCommand _ } -> []
-             CreateProcess { cmdspec = RawCommand _ args' } -> args'
+    (cmd, args) = case cp of
+            CreateProcess { cmdspec = ShellCommand sc } -> (sc, [])
+            CreateProcess { cmdspec = RawCommand fp args' } -> (fp, args')
 
 
 -- | @readProcessWithExitCode@ is like 'readProcess' but with two differences:

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -361,7 +361,7 @@ callProcess cmd = callCreateProcess_ "callProcess" . proc cmd
 --
 -- @since 1.2.0.0
 callCommand :: String -> IO ()
-callCommand cmd = callCreateProcess_ "callCommand" (shell cmd)
+callCommand = callCreateProcess_ "callCommand" . shell
 
 callCreateProcess_ :: String -> CreateProcess -> IO ()
 callCreateProcess_ fun command = do

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -363,8 +363,7 @@ callProcess cmd args = do
 -- @since 1.2.0.0
 callCommand :: String -> IO ()
 callCommand cmd = do
-    let command = shell cmd
-    callCreateProcess_ "callCommand" command
+    callCreateProcess_ "callCommand" (shell cmd)
 
 callCreateProcess_ :: String -> CreateProcess -> IO ()
 callCreateProcess_ fun command = do

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -362,8 +362,7 @@ callProcess cmd args = do
 --
 -- @since 1.2.0.0
 callCommand :: String -> IO ()
-callCommand cmd = do
-    callCreateProcess_ "callCommand" (shell cmd)
+callCommand cmd = callCreateProcess_ "callCommand" (shell cmd)
 
 callCreateProcess_ :: String -> CreateProcess -> IO ()
 callCreateProcess_ fun command = do

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, ForeignFunctionInterface #-}
+{-# LANGUAGE LambdaCase #-}
 #if __GLASGOW_HASKELL__ >= 709
 {-# LANGUAGE Safe #-}
 #else
@@ -374,6 +375,11 @@ callCommand cmd = do
       ExitSuccess   -> return ()
       ExitFailure r -> processFailedException "callCommand" cmd [] r
 
+processFailed :: String -> CmdSpec -> Int -> IO a
+processFailed fun = \ case
+    ShellCommand cmd -> processFailedException fun cmd []
+    RawCommand cmd args -> processFailedException fun cmd args
+
 processFailedException :: String -> String -> [String] -> Int -> IO a
 processFailedException fun cmd args exit_code =
       ioError (mkIOError OtherError (fun ++ ": " ++ cmd ++
@@ -574,14 +580,9 @@ readCreateProcess cp input = do
 
     case ex of
      ExitSuccess   -> return output
-     ExitFailure r -> processFailed r
+     ExitFailure r -> processFailed fun (cmdspec cp) r
   where
     fun = "readCreateProcess"
-    processFailed = case cp of
-            CreateProcess { cmdspec = ShellCommand sc } ->
-              processFailedException fun sc []
-            CreateProcess { cmdspec = RawCommand fp args' } ->
-              processFailedException fun fp args'
 
 
 -- | @readProcessWithExitCode@ is like 'readProcess' but with two differences:

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -350,8 +350,7 @@ spawnCommand cmd = do
 -- @since 1.2.0.0
 callProcess :: FilePath -> [String] -> IO ()
 callProcess cmd args = do
-    let command = proc cmd args
-    callCreateProcess_ "callProcess" command
+    callCreateProcess_ "callProcess" (proc cmd args)
 
 -- | Creates a new process to run the specified shell command.  If the
 -- command returns a non-zero exit code, an exception is raised.

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -41,6 +41,7 @@ module System.Process (
     ProcessHandle,
 
     -- ** Simpler functions for common tasks
+    callCreateProcess,
     callProcess,
     callCommand,
     spawnProcess,
@@ -337,6 +338,19 @@ spawnCommand cmd = do
 
 -- ----------------------------------------------------------------------------
 -- callProcess/callCommand
+
+-- | Creates a new process from the provided `CreateProcess`, and wait for it
+-- to finish.  If the process returns a non-zero exit code, an exception is
+-- raised.
+--
+-- If an asynchronous exception is thrown to the thread executing
+-- @callCreateProcess@, the forked process will be terminated and
+-- @callCreateProcess@ will wait (block) until the process has been
+-- terminated.
+--
+-- @since TODO
+callCreateProcess :: CreateProcess -> IO ()
+callCreateProcess = callCreateProcess_ "callCreateProcess"
 
 -- | Creates a new process to run the specified command with the given
 -- arguments, and wait for it to finish.  If the command returns a non-zero

--- a/System/Process.hs
+++ b/System/Process.hs
@@ -375,7 +375,7 @@ callCommand cmd = do
                    waitForProcess p
     case exit_code of
       ExitSuccess   -> return ()
-      ExitFailure r -> processFailedException "callCommand" cmd [] r
+      ExitFailure r -> processFailed "callCommand" (cmdspec command) r
 
 processFailed :: String -> CmdSpec -> Int -> IO a
 processFailed fun = \ case

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## next
+* Add `callCreateProcess`
+
 ## 1.6.27.0 *March 2026*
 
 * Support being configured without fork


### PR DESCRIPTION
- analog to `readCreateProcess`
- this also removes code duplication between `callProcess` and `callCommand`