### PR TITLE
fix: certain macos sdks set symbols to NULL, resulting in segfaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,9 @@ jobs:
       matrix:
         platform:
           - { os: ubuntu-latest, arch: x64 }
-          - { os: macos-14, arch: x64 }
-          - { os: macos-14, arch: arm }
+          - { os: macos-15, arch: x64 }
+          - { os: macos-15, arch: arm }
+          - { os: macos-26, arch: arm }
           - { os: windows-latest, arch: x64 }
         ghc-version:
           - 'latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,19 @@ jobs:
           - platform:
               arch: arm
             ghc-version: '8.6'
+          # macos >= 14 ships with a libtinfo version that is too recent; arm is excluded anyway
+          - platform:
+              os: macos-15
+            ghc-version: '9.0'
+          - platform:
+              os: macos-15
+            ghc-version: '8.10'
+          - platform:
+              os: macos-15
+            ghc-version: '8.8'
+          - platform:
+              os: macos-15
+            ghc-version: '8.6'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
           - { os: windows-latest, arch: x64 }
         ghc-version:
           - 'latest'
+          - '9.14'
+          - '9.12'
           - '9.10'
           - '9.8'
           - '9.6'

--- a/cbits/posix/posix_spawn.c
+++ b/cbits/posix/posix_spawn.c
@@ -138,7 +138,22 @@ do_spawn_posix (char *const args[],
 
     if (workingDirectory) {
 #if defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR)
+#if defined(HAVE_POSIX_SPAWN_FILE_ACTIONS_ADDCHDIR_NP)
+        // N.B. in certain toolchain versions, apple will act as if symbols exist
+        // because the toolchain can be *used* for targets that have them.
+        // At runtime, however, they will be NULL. So, if both symbols are
+        // available, first check if the _np version *should* be available,
+        // if it is, add a runtime check whether the non-_np version is NULL
+        // and fallback to the _np version if it is
+        // See also: https://github.com/haskell/process/issues/356
+        if (posix_spawn_file_actions_addchdir == NULL) {
+          r = posix_spawn_file_actions_addchdir_np(&fa, workingDirectory);
+        } else {
+          r = posix_spawn_file_actions_addchdir(&fa, workingDirectory);
+        }
+#else
         r = posix_spawn_file_actions_addchdir(&fa, workingDirectory);
+#endif
         if (r != 0) {
             *failed_doing = "posix_spawn_file_actions_addchdir";
             goto fail;

--- a/test/Setup.hs
+++ b/test/Setup.hs
@@ -32,7 +32,7 @@ import Distribution.Types.TargetInfo
   ( targetComponent )
 import Distribution.Types.UnqualComponentName
   ( unUnqualComponentName )
-#if MIN_VERSION_Cabal(3,16,0)
+#if MIN_VERSION_Cabal(3,14,0)
 import Distribution.Utils.Path
   ( SymbolicPathX, interpretSymbolicPathCWD)
 #endif
@@ -50,7 +50,7 @@ import System.FilePath
 main :: IO ()
 main = defaultMainWithHooks testProcessHooks
 
-#if MIN_VERSION_Cabal(3,16,0)
+#if MIN_VERSION_Cabal(3,14,0)
 pathToString ::
   SymbolicPathX allowAbsolute from to -> String
 pathToString = interpretSymbolicPathCWD

--- a/test/main.hs
+++ b/test/main.hs
@@ -55,6 +55,8 @@ main = do
     testDoubleWait
     testKillDoubleWait
     testCreateProcess
+    testAddChdir
+    testAddChdir2
     testCommunicationHandle False
 #if defined(__IO_MANAGER_WINIO__)
     -- With WinIO, also run the test with the child process using WinIO
@@ -331,6 +333,22 @@ testCommunicationHandle childUsesWinIO = do
     ExitFailure {} ->
       error $ "testCommunicationHandle: child exited with exception " ++ show ex
   putStrLn "testCommunicationHandle }"
+
+testAddChdir :: IO ()
+testAddChdir = run "testAddChdir" $ handleIOErr $ do
+  (_, _, _, commhand) <-
+      runInteractiveProcess "true" [] (Just "/no/such/dir") Nothing
+  exitCode <- waitForProcess commhand
+  print exitCode
+  where handleIOErr a = a `catchIOError` \e -> putStrLn ("Exc: " ++ show (ioeGetErrorType e))
+
+testAddChdir2 :: IO ()
+testAddChdir2 = run "testAddChdir2" $ handleIOErr $ do
+  commhand <- runProcess "true" [] (Just "/no/such/dir") Nothing
+                Nothing Nothing Nothing
+  exitCode <- waitForProcess commhand
+  print exitCode
+  where handleIOErr a = a `catchIOError` \e -> putStrLn ("Exc: " ++ show (ioeGetErrorType e))
 
 withCurrentDirectory :: FilePath -> IO a -> IO a
 withCurrentDirectory new inner = do


### PR DESCRIPTION
```
    In certain toolchain versions, apple will act as if symbols exist
    because the toolchain *can be used* for targets that have them.
    At runtime, however, they will be NULL.
    This resulted in a segfault trying to use the
    posix_spawn_file_actions_addchidr symbol.
    The resultion is as follows: If both symbols are available, first
    check if the _np version *should* be available, if it is, add
    a runtime check whether the non-_np version is NULL and fallback
    to the _np version if it is.

    The easiest and safest fix here would be to move both checks entirely to
    the runtime, but for conservativity reasons this was not done.
```

Also a couple changes to ci
- make build on ghc 9.12
- make build on newer macos 
- build a test that only runs upstream (ghc) normally

Resolves #356.