### PR TITLE
Stub out runProcess.c on wasm32

### DIFF
--- a/cbits/posix/runProcess.c
+++ b/cbits/posix/runProcess.c
@@ -5,6 +5,11 @@
    ------------------------------------------------------------------------- */
 
 #include "runProcess.h"
+
+// Callers are stubbed out on wasm32: runInteractiveProcess (System/Process/Posix.hs),
+// terminateProcess, getProcessExitCode, waitForProcess (System/Process.hs).
+#if !defined(wasm32_HOST_ARCH)
+
 #include "common.h"
 
 #include <unistd.h>
@@ -271,3 +276,5 @@ waitForProcess (ProcHandle handle, int *pret)
 
     return -1;
 }
+
+#endif // !wasm32_HOST_ARCH

--- a/process.cabal
+++ b/process.cabal
@@ -94,7 +94,7 @@ library
 
     ghc-options: -Wall
 
-    build-depends: base      >= 4.12.0.0 && < 4.23,
+    build-depends: base      >= 4.12.0.0 && < 4.24,
                    directory >= 1.1 && < 1.4,
                    deepseq   >= 1.1 && < 1.6
 

--- a/test/process-tests.cabal
+++ b/test/process-tests.cabal
@@ -22,7 +22,7 @@ common process-dep
 
 custom-setup
   setup-depends:
-    base      >= 4.10 && < 4.23,
+    base      >= 4.10 && < 4.24,
     directory >= 1.1  && < 1.4,
     filepath  >= 1.2  && < 1.6,
     Cabal     >= 2.4  && < 3.18,


### PR DESCRIPTION
Also bump base upper bound to < 4.24 for GHC 10.0

I can open a new MR for the base bound bump, but since we don't have CI setup
for wasm32-wasi, it was more convienent to have both changes in a single branch so that
this change can be tested on GHC CI: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/15978

Fixes #357
