### PR TITLE
feat: add a release workflow

### DIFF
--- a/.github/workflows/prepare-release-artifacts.yml
+++ b/.github/workflows/prepare-release-artifacts.yml
@@ -1,0 +1,68 @@
+name: prepare release artifacts
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    outputs:
+      sdist-artifact-id: ${{ steps.upload-sdist.outputs.artifact-id }}
+
+    steps:
+      - uses: haskell/ghcup-setup@v1
+      - run: ghcup install ghc --set latest
+
+      - uses: actions/checkout@v6
+
+      - run: autoreconf -Wall
+      - run: cabal check
+      - run: cabal sdist
+
+      - name: upload sdist
+        id: upload-sdist
+        uses: actions/upload-artifact@v7
+        with:
+          name: sdist
+          path: dist-newstyle/sdist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 90
+
+  smoketest:
+    needs: sdist
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - name: download sdist
+        uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.sdist.outputs.sdist-artifact-id }}
+
+      - name: extract sdist
+        shell: bash
+        run: |
+          ls -la
+          tar -xzf *.tar.gz --strip-components=1
+          chmod +x ./configure
+
+      - name: configure smoketest
+        shell: bash
+        run: ./configure
+
+      - name: upload config.log
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.os }}.config.log
+          path: ./config.log
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: job summary
+        shell: bash
+        run: |
+          echo '### config.log (`${{ matrix.os }}`)' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat config.log >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -29,3 +29,19 @@ autoconf -i
 
 (WARNING: `git clean -fxd` will delete all untracked files in the
 repo)
+
+To make the release process more observable and less dependent on the system
+of the maintainer, there's a workflow creating an sdist.
+
+This sdist ought to be generated as follows:
+- navigate to the workflow run created for the commit you want to generate an
+  sdist for. Or, if none was created automatically then create one by navigating
+  to the Actions tab, selecting the "prepare release artifacts" workflow, and launching
+  a run using the "`workflow_dispatch` event trigger" that you will find there.
+- navigate to the "prepare release artifacts" job group in the github UI
+- carefully sanity check the output of the "smoketest" in github UI.
+  These can also be downloaded as an artifact for local inspection. A sanity check
+  would e.g. entail look at whether `posix_spawn.*` symbols are recognised and
+  configured correctly.
+- afterwards, download the sdist from the release page by scrolling all the way down,
+  then downloading the `sdist`. Upload it as a candidate and proceed as usual.


### PR DESCRIPTION
Adds a new release workflow. This workflow adds a couple of things 
- runs autoreconf and cabal sdist
- uploads the sdist as an artifact
- unpacks the sdist in another container
- runs configure script there
- uploads the configure log as artifact and as job summary (e.g. https://github.com/haskell/process/actions/runs/25102571704) for sanity checking 
- documentation on how to use this information 

<img width="1774" height="1512" alt="image" src="https://github.com/user-attachments/assets/7006a4db-7972-40ad-8e88-4d84096e87f2" />