### PR TITLE
Add a basic editorconfig file. 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+tab_width = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
Editorconfig can be used to unintrusevely make editors cohere with basic formatting standards used in a projects, e.g. 
- tabs vs spaces 
- default tab width (i.e. when doing line breaks) 
- trailing whitespace 
- file encoding

It is supported by all major editors and doesn't need any extra configuration in most. 

Vscode and neovim for example just make it work out of the box. 