### PR TITLE
darwin: Allow posix_spawn_file_actions_addchdir to be missing when linking against process

### DIFF
--- a/process.cabal
+++ b/process.cabal
@@ -87,6 +87,19 @@ library
                 cbits/posix/find_executable.c
             other-modules: System.Process.Posix
 
+    -- On macOS, posix_spawn_file_actions_addchdir is available from macOS >= 26.
+    -- We weakly reference this symbol when we are build on such a platform.
+    -- However, weak references on MachO are hints to the dynamic loader, not the
+    -- static linker, which will still expect the symbol to be defined somewhere.
+    -- This means linking fails when we try to link an executable depending on
+    -- process on a toolchain which doesn't have this symbol against a process
+    -- library build on a toolchain with the symbol.
+    -- See https://github.com/haskell/process/issues/376
+    -- Hence: instruct the linker to explicilty allow undefined references to
+    -- the symbol when linking against process on darwin
+    if os(darwin)
+        ld-options: -Wl,-U,_posix_spawn_file_actions_addchdir
+
     include-dirs: include
     install-includes:
         runProcess.h


### PR DESCRIPTION
In 0699e410418f5fe8eaf164ce21048b8b25c9b112 we attempted to account for darwin toolchains missing this symbol, which is imported as a weak references.

However, weak references on MachO objects don't work the same way as on ELF (see https://github.com/iains/gcc-darwin-arm64/discussions/133). A final link with undefined weak references still fails.

To fix this, on darwin, we explicilty add `-Wl,-U,_posix_spawn_file_actions_addchdir` to `ld-options` so anything linking against process explicilty instructs the linker to ignore undefined references to this symbol (set it to NULL at runtime).

Fixes #376