### PR TITLE
Windows: improve "close_fds=True" spawning

### DIFF
--- a/System/Process/Common.hs
+++ b/System/Process/Common.hs
@@ -98,7 +98,7 @@ data CreateProcess = CreateProcess{
   std_out      :: StdStream,               -- ^ How to determine stdout
   std_err      :: StdStream,               -- ^ How to determine stderr
   -- XXX verify what happens with fds in nodejs child processes
-  close_fds    :: Bool,                    -- ^ Close all file descriptors except stdin, stdout and stderr in the new process (on Windows, only works if std_in, std_out, and std_err are all Inherit). This implementation will call close on every fd from 3 to the maximum of open files, which can be slow for high maximum of open files.
+  close_fds    :: Bool,                    -- ^ Close all file descriptors except stdin, stdout and stderr in the new process. On POSIX this implementation will call close on every fd from 3 to the maximum of open files, which can be slow for high maximum of open files.
   create_group :: Bool,                    -- ^ Create a new process group. On JavaScript this also creates a new session.
   delegate_ctlc:: Bool,                    -- ^ Delegate control-C handling. Use this for interactive console processes to let them handle control-C themselves (see below for details).
                                            --

--- a/System/Process/Windows.hsc
+++ b/System/Process/Windows.hsc
@@ -130,17 +130,7 @@ createProcess_Internal_mio fun def@CreateProcess{
        fdout <- mbFd fun fd_stdout mb_stdout
        fderr <- mbFd fun fd_stderr mb_stderr
 
-       -- #2650: we must ensure mutual exclusion of c_runInteractiveProcess,
-       -- because otherwise there is a race condition whereby one thread
-       -- has created some pipes, and another thread spawns a process which
-       -- accidentally inherits some of the pipe handles that the first
-       -- thread has created.
-       --
-       -- An MVar in Haskell is the best way to do this, because there
-       -- is no way to do one-time thread-safe initialisation of a mutex
-       -- the C code.  Also the MVar will be cheaper when not running
-       -- the threaded RTS.
-       proc_handle <- withMVar runInteractiveProcess_lock $ \_ ->
+       proc_handle <- withSpawnLock mb_close_fds $
                       throwErrnoIfBadPHandle fun $
                            c_runInteractiveProcess pcmdline pWorkDir pEnv
                                   fdin fdout fderr
@@ -229,17 +219,7 @@ createProcess_Internal_winio fun def@CreateProcess{
      hwnd_out <- mbHANDLE _stdout mb_stdout
      hwnd_err <- mbHANDLE _stderr mb_stderr
 
-     -- #2650: we must ensure mutual exclusion of c_runInteractiveProcess,
-     -- because otherwise there is a race condition whereby one thread
-     -- has created some pipes, and another thread spawns a process which
-     -- accidentally inherits some of the pipe handles that the first
-     -- thread has created.
-     --
-     -- An MVar in Haskell is the best way to do this, because there
-     -- is no way to do one-time thread-safe initialisation of a mutex
-     -- the C code.  Also the MVar will be cheaper when not running
-     -- the threaded RTS.
-     proc_handle <- withMVar runInteractiveProcess_lock $ \_ ->
+     proc_handle <- withSpawnLock mb_close_fds $
                     throwErrnoIfBadPHandle fun $
                          c_runInteractiveProcessHANDLE pcmdline pWorkDir pEnv
                                 hwnd_in hwnd_out hwnd_err
@@ -267,9 +247,94 @@ createProcess_Internal_winio fun def@CreateProcess{
 
 ##endif
 
-{-# NOINLINE runInteractiveProcess_lock #-}
-runInteractiveProcess_lock :: MVar ()
-runInteractiveProcess_lock = unsafePerformIO $ newMVar ()
+{- Note [Concurrent process spawning]
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+GHC bug #2650 showed that we need to be careful to avoid child processes
+inheriting unwanted handles on Windows.
+
+The 'close_fds' field of 'CreateProcess' specifies the expected behaviour:
+
+  - 'close_fds = False': the child process will inherit all inheritable
+    handles from the parent.
+  - 'close_fds = True': the child process is handed an explicit list of handles
+    it may inherit.
+
+In a concurrent setting, the first behaviour is problematic: spawning happens
+in two steps (first creating handles and then calling CreateProcess), but we
+don't want a child process to inherit handles created for other (concurrently
+spawned) children, which can cause write-ends to be left permanently open.
+That was the bug in #2650.
+
+The initial fix for this bug, in commit 5deecb284ed7b49402805ef64011b5c8a075a09c,
+solved this by serialising all process creation, using a single MVar. However,
+this is too strong: we only need to ensure that no process creation that uses
+'close_fds = False' is concurrent with any process creation (of any kind).
+Re-phrasing: 'close_fds = False' spawns must be exclusive.
+
+To allow concurrent spawns of 'close_fds = True' processes, we weaken the MVar
+lock: it is held **either** by a single 'close_fds = False' spawn, or jointly
+by a collection of 'close_fds = True' spawns. We differentiate the two by a
+second 'MVar', 'shared_spawns_count', which counts how many joint
+'close_fds = True' spawns are currently underway.
+Fairness is implemented using a third 'MVar', the turnstile. A waiting exclusive
+spawn holds the turnstile 'MVar', so that further non-exclusive spawns are put
+on wait rather than accumulating with existing in-flight shared spawns, which
+could end up starving exclusive spawns.
+
+The solution is implemented on the Haskell side using 'MVar's, because there is
+no way to do one-time thread-safe initialisation of a mutex in the C code.
+-}
+
+-- | A lock used to implement the locking mechanism of
+-- Note [Concurrent process spawning].
+data SpawnLock =
+  SpawnLock
+    { spawn_lock :: !(MVar ())
+      -- ^ lock to hold for concurrent process creation
+    , shared_spawns_count :: !(MVar Int)
+      -- ^ how many @close_fds = True@ spawns are in flight
+    , spawn_turnstile :: !(MVar ())
+      -- ^ turnstile used to implement the fairness guarantee
+      -- in Note [Concurrent process spawning]
+    }
+
+{-# NOINLINE spawnLock #-}
+spawnLock :: SpawnLock
+spawnLock = unsafePerformIO $
+  SpawnLock <$> newMVar () <*> newMVar 0 <*> newMVar ()
+
+-- | Spawn a process, using the locking mechanism detailed in
+-- Note [Concurrent process spawning].
+withSpawnLock
+  :: Bool  -- ^ @close_fds@
+  -> IO a
+  -> IO a
+withSpawnLock closeFds act
+  | closeFds  = bracket_ acquireShared releaseShared act
+  | otherwise = withMVar (spawn_turnstile spawnLock) $ \_ ->
+                withMVar (spawn_lock spawnLock) $ \_ -> act
+  where
+    acquireShared =
+      -- Wait our turn (wait on the turnstile).
+      mask_ $ withMVar (spawn_turnstile spawnLock) $ \_ -> do
+        -- The first shared spawn takes the lock.
+        n <- takeMVar (shared_spawns_count spawnLock)
+        (do when (n == 0) $ takeMVar (spawn_lock spawnLock)
+            putMVar (shared_spawns_count spawnLock) (n + 1)
+          ) `onException` putMVar (shared_spawns_count spawnLock) n
+
+    releaseShared =
+      mask_ $ do
+        -- Don't wait on the turnstile: this is exactly what a pending exclusive
+        -- spawn is waiting on, so waiting here would deadlock.
+
+        -- The last shared spawn finishing releases the lock.
+        n <- takeMVar (shared_spawns_count spawnLock)
+        (do when (n == 1) $ putMVar (spawn_lock spawnLock) ()
+            -- Release before updating the count to ensure the count is always
+            -- conservative.
+            putMVar (shared_spawns_count spawnLock) (n - 1)
+          ) `onException` putMVar (shared_spawns_count spawnLock) n
 
 -- ----------------------------------------------------------------------------
 -- Delegated control-C handling on Windows

--- a/cbits/win32/runProcess.c
+++ b/cbits/win32/runProcess.c
@@ -6,6 +6,14 @@
 
 #define UNICODE
 
+/* We need _WIN32_WINNT >= 0x0600 for STARTUPINFOEX and PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+   while the MINGW toolchains bundled with older GHCs (prior to GHC 9.4) default
+   it to below that.  */
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0600
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
 /* XXX This is a nasty hack; should put everything necessary in this package */
 #include "HsBase.h"
 #include "Rts.h"
@@ -295,7 +303,11 @@ runInteractiveProcessWrapper (
     HANDLE *pStdInput, HANDLE *pStdOutput, HANDLE *pStdError,
     int flags, bool useJobObject, HANDLE *hJob, bool asynchronous)
 {
-    STARTUPINFO sInfo;
+    STARTUPINFOEX sInfoEx;
+    STARTUPINFO *sInfo = &sInfoEx.StartupInfo;
+    LPPROC_THREAD_ATTRIBUTE_LIST attrList = NULL;
+    HANDLE inheritedHandles[3];
+    DWORD nInheritedHandles = 0;
     PROCESS_INFORMATION pInfo;
     HANDLE hStdInputRead   = INVALID_HANDLE_VALUE;
     HANDLE hStdInputWrite  = INVALID_HANDLE_VALUE;
@@ -303,38 +315,39 @@ runInteractiveProcessWrapper (
     HANDLE hStdOutputWrite = INVALID_HANDLE_VALUE;
     HANDLE hStdErrorRead   = INVALID_HANDLE_VALUE;
     HANDLE hStdErrorWrite  = INVALID_HANDLE_VALUE;
+    HANDLE job             = NULL;
     BOOL close_fds = ((flags & RUN_PROCESS_IN_CLOSE_FDS) != 0);
     // We always pass a wide environment block, so we MUST set this flag
     DWORD dwFlags = CREATE_UNICODE_ENVIRONMENT;
     BOOL inherit;
 
-    ZeroMemory(&sInfo, sizeof(sInfo));
-    sInfo.cb = sizeof(sInfo);
-    sInfo.dwFlags = STARTF_USESTDHANDLES;
+    ZeroMemory(&sInfoEx, sizeof(sInfoEx));
+    sInfo->cb = sizeof(*sInfo);
+    sInfo->dwFlags = STARTF_USESTDHANDLES;
     ZeroMemory(&pInfo, sizeof(pInfo));
 
     HANDLE defaultStdIn     = GetStdHandle(STD_INPUT_HANDLE);
     HANDLE defaultStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
     HANDLE defaultStdError  = GetStdHandle(STD_ERROR_HANDLE);
 
-    if (!setStdHandleInfo (&sInfo.hStdInput, _stdin, &hStdInputRead,
+    if (!setStdHandleInfo (&sInfo->hStdInput, _stdin, &hStdInputRead,
                            &hStdInputWrite, defaultStdIn, TRUE, FALSE,
                            asynchronous))
       goto cleanup_err;
 
-    if (!setStdHandleInfo (&sInfo.hStdOutput, _stdout, &hStdOutputRead,
+    if (!setStdHandleInfo (&sInfo->hStdOutput, _stdout, &hStdOutputRead,
                            &hStdOutputWrite, defaultStdOutput, FALSE, TRUE,
                            asynchronous))
       goto cleanup_err;
 
-    if (!setStdHandleInfo (&sInfo.hStdError, _stderr, &hStdErrorRead,
+    if (!setStdHandleInfo (&sInfo->hStdError, _stderr, &hStdErrorRead,
                            &hStdErrorWrite, defaultStdError, FALSE, TRUE,
                            asynchronous))
       goto cleanup_err;
 
-    if (sInfo.hStdInput     !=  defaultStdIn
-        && sInfo.hStdOutput !=  defaultStdOutput
-        && sInfo.hStdError  !=  defaultStdError
+    if (sInfo->hStdInput     !=  defaultStdIn
+        && sInfo->hStdOutput !=  defaultStdOutput
+        && sInfo->hStdError  !=  defaultStdError
         && (flags & RUN_PROCESS_IN_NEW_GROUP) == 0)
             dwFlags |= CREATE_NO_WINDOW;   // Run without console window only when both output and error are redirected
 
@@ -346,6 +359,53 @@ runInteractiveProcessWrapper (
         inherit = FALSE;
     } else {
         inherit = TRUE;
+    }
+
+    /* close_fds: inherit the standard handles and nothing else, using
+       PROC_THREAD_ATTRIBUTE_HANDLE_LIST. */
+    if (close_fds && inherit) {
+        HANDLE candidates[3] = { sInfo->hStdInput, sInfo->hStdOutput, sInfo->hStdError };
+        for (int i = 0; i < 3; i++) {
+            HANDLE h = candidates[i];
+            if (h == NULL || h == INVALID_HANDLE_VALUE) continue;
+            bool dup = false;
+            for (DWORD j = 0; j < nInheritedHandles; j++)
+                if (inheritedHandles[j] == h) dup = true;
+            if (!dup) inheritedHandles[nInheritedHandles++] = h;
+        }
+    }
+
+    if (close_fds && inherit && nInheritedHandles == 0) {
+        /* UpdateProcThreadAttribute requires a non-empty list of handles;
+           shortcut if there are no handles to inherit. */
+        inherit = FALSE;
+    } else if (nInheritedHandles > 0) {
+        SIZE_T attrSize = 0;
+        InitializeProcThreadAttributeList(NULL, 1, 0, &attrSize);
+        if (attrSize == 0) {
+            SetLastError(ERROR_INVALID_PARAMETER);
+            goto cleanup_err;
+        }
+        attrList = (LPPROC_THREAD_ATTRIBUTE_LIST) HeapAlloc(GetProcessHeap(), 0, attrSize);
+        if (attrList == NULL) {
+            SetLastError(ERROR_NOT_ENOUGH_MEMORY);
+            goto cleanup_err;
+        }
+        if (!InitializeProcThreadAttributeList(attrList, 1, 0, &attrSize)) {
+            DWORD err = GetLastError();
+            HeapFree(GetProcessHeap(), 0, attrList);
+            attrList = NULL;
+            SetLastError(err);
+            goto cleanup_err;
+        }
+        if (!UpdateProcThreadAttribute(attrList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                       inheritedHandles,
+                                       nInheritedHandles * sizeof(HANDLE),
+                                       NULL, NULL))
+            goto cleanup_err;
+        sInfoEx.lpAttributeList = attrList;
+        sInfo->cb = sizeof(sInfoEx);
+        dwFlags |= EXTENDED_STARTUPINFO_PRESENT;
     }
 
     if ((flags & RUN_PROCESS_IN_NEW_GROUP) != 0) {
@@ -364,24 +424,28 @@ runInteractiveProcessWrapper (
     if (useJobObject)
     {
         dwFlags |= CREATE_SUSPENDED;
-        *hJob = createJob();
-        if (!*hJob)
+        job = createJob();
+        if (!job)
         {
             goto cleanup_err;
         }
-    } else {
-        *hJob = NULL;
     }
 
-    if (!CreateProcess(NULL, cmd, NULL, NULL, inherit, dwFlags, environment, workingDirectory, &sInfo, &pInfo))
+    if (!CreateProcess(NULL, cmd, NULL, NULL, inherit, dwFlags, environment, workingDirectory, sInfo, &pInfo))
     {
         goto cleanup_err;
     }
 
-    if (useJobObject && hJob && *hJob)
+    if (attrList != NULL) {
+        DeleteProcThreadAttributeList(attrList);
+        HeapFree(GetProcessHeap(), 0, attrList);
+        attrList = NULL;
+    }
+
+    if (job)
     {
         // Then associate the process and the job;
-        if (!AssignProcessToJobObject (*hJob, pInfo.hProcess))
+        if (!AssignProcessToJobObject (job, pInfo.hProcess))
         {
             goto cleanup_err;
         }
@@ -400,10 +464,11 @@ runInteractiveProcessWrapper (
     if (hStdOutputWrite != INVALID_HANDLE_VALUE) CloseHandle(hStdOutputWrite);
     if (hStdErrorWrite  != INVALID_HANDLE_VALUE) CloseHandle(hStdErrorWrite);
 
-    // Return the pointers to the handles we need.
+    // SUCCESS: write to all the output parameters.
     *pStdInput  = hStdInputWrite;
     *pStdOutput = hStdOutputRead;
     *pStdError  = hStdErrorRead;
+    *hJob       = job;
 
     return pInfo.hProcess;
 
@@ -414,7 +479,13 @@ cleanup_err:
     if (hStdOutputWrite != INVALID_HANDLE_VALUE) CloseHandle(hStdOutputWrite);
     if (hStdErrorRead   != INVALID_HANDLE_VALUE) CloseHandle(hStdErrorRead);
     if (hStdErrorWrite  != INVALID_HANDLE_VALUE) CloseHandle(hStdErrorWrite);
-    if (useJobObject && hJob      && *hJob     ) CloseHandle(*hJob);
+    if (job             != NULL                ) CloseHandle(job);
+    if (attrList != NULL) {
+        DWORD err = GetLastError();
+        DeleteProcThreadAttributeList(attrList);
+        HeapFree(GetProcessHeap(), 0, attrList);
+        SetLastError(err);
+    }
 
     maperrno();
     return NULL;

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog for [`process` package](http://hackage.haskell.org/package/process)
 
+## Unreleased
+
+* On Windows, `close_fds` is now respected: child processes no longer inherit
+  all of the inheritable handles of the parent process.
+* On Windows, process spawned with `close_fds = True` can now be spawned
+  concurrently with eachother.
+
 ## 1.6.30.0 *June 2026*
 
 * darwin: Allow posix_spawn_file_actions_addchdir to be missing when

--- a/test/main.hs
+++ b/test/main.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Control.Exception
-import Control.Monad (guard, unless, void, when)
+import Control.Monad (forM_, guard, unless, void, when)
 import System.Exit
 import System.IO.Error
 import System.Directory (getCurrentDirectory, setCurrentDirectory)
@@ -57,6 +57,8 @@ main = do
     testCreateProcess
     testAddChdir
     testAddChdir2
+    testCloseFdsStdStreams
+    testCloseFdsHandleInheritance
     testCommunicationHandle False
 #if defined(__IO_MANAGER_WINIO__)
     -- With WinIO, also run the test with the child process using WinIO
@@ -298,6 +300,43 @@ testCreateProcess = run "createProcess with cwd = Nothing" $ do
         Left e -> error $ "waitForProcess threw: " ++ show (e :: SomeException)
         Right ExitSuccess -> return ()
         Right exitCode -> error $ "unexpected exit code: " ++ show exitCode
+
+-- Check all combinations of 'close_fds' with the set of streams to inherit.
+testCloseFdsStdStreams :: IO ()
+testCloseFdsStdStreams = run "close_fds with all std stream combinations" $
+    forM_ [ (cf, si, so, se)
+          | cf <- [False, True], si <- streams, so <- streams, se <- streams ] $
+      \combination@(cf, si, so, se) ->
+        handle (\e -> error (show combination ++ ": " ++ show (e :: IOException))) $ do
+          (hi, ho, he, ph) <- createProcess (proc "echo" ["hello"])
+            { std_in = si, std_out = so, std_err = se, close_fds = cf }
+          mapM_ hClose hi
+          mapM_ hClose ho
+          mapM_ hClose he
+          void $ waitForProcess ph
+  where
+    streams = [Inherit, CreatePipe, NoStream]
+
+-- Check that a child spawned with @close_fds@ doesn't inherit handles that
+-- it shouldn't.
+testCloseFdsHandleInheritance :: IO ()
+testCloseFdsHandleInheritance = run "close_fds does not leak unrelated handles" $ do
+    -- An inheritable pipe that the child has no business holding on to.
+    (weRead, theyWrite) <- createWeReadTheyWritePipe
+    -- Create a process that blocks reading stdin (cat).
+    (Just toChild, _, _, ph) <- createProcess (proc "cat" [])
+      { std_in = CreatePipe, close_fds = True }
+    closeCommunicationHandle theyWrite
+    -- We closed the write end so we should see EOF... unless the child inherited
+    -- it and keeps it open.
+    eof <- newEmptyMVar
+    _ <- forkIO $ (hGetContents weRead >>= evaluate . length) >>= void . tryPutMVar eof . Just
+    _ <- forkIO $ threadDelay 5000000 >> void (tryPutMVar eof Nothing)
+    sawEof <- takeMVar eof
+    hClose toChild
+    _ <- waitForProcess ph
+    unless (sawEof == Just 0) $
+      error "close_fds child inherited a handle it should not have"
 
 testCommunicationHandle :: Bool -> IO ()
 testCommunicationHandle childUsesWinIO = do


### PR DESCRIPTION
Ticket: #381.

Two fixes to process spawning with "close_fds = True" on Windows:

  1. Use PROC_THREAD_ATTRIBUTE_HANDLE_LIST to avoid inheriting handles from the parent.
  2. Allow concurrent spawns of subprocesses with "close_fds = True".
